### PR TITLE
Added unit test for request builder

### DIFF
--- a/include/up-cpp/client/usubscription/v3/RequestBuilder.h
+++ b/include/up-cpp/client/usubscription/v3/RequestBuilder.h
@@ -1,6 +1,8 @@
 #ifndef REQUESTBUILDER_H
 #define REQUESTBUILDER_H
 #include <up-cpp/utils/ProtoConverter.h>
+
+#include <utility>
 #include "up-cpp/client/usubscription/v3/RpcClientUSubscription.h"
 
 
@@ -28,8 +30,8 @@ struct USubscriptionOptions {
 
 	struct RequestBuilder {
 		 explicit RequestBuilder(
-	        const USubscriptionOptions& options = {})
-			:options_(options){};
+	        USubscriptionOptions options = {})
+			:options_(std::move(options)){};
 
 		SubscriptionRequest buildSubscriptionRequest(const v1::UUri& topic) const;
 

--- a/include/up-cpp/client/usubscription/v3/RequestBuilder.h
+++ b/include/up-cpp/client/usubscription/v3/RequestBuilder.h
@@ -3,7 +3,6 @@
 #include <up-cpp/utils/ProtoConverter.h>
 
 #include <utility>
-#include "up-cpp/client/usubscription/v3/RpcClientUSubscription.h"
 
 
 namespace uprotocol::core::usubscription::v3 {
@@ -35,7 +34,7 @@ struct USubscriptionOptions {
 
 		SubscriptionRequest buildSubscriptionRequest(const v1::UUri& topic) const;
 
-		UnsubscribeRequest buildUnsubscribeRequest(const v1::UUri& topic);
+		static UnsubscribeRequest buildUnsubscribeRequest(const v1::UUri& topic);
 	private:
 		USubscriptionOptions options_;
 	};

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -48,7 +48,7 @@ struct RpcClientUSubscription : USubscription {
 	/// @brief Constructor
 	///
 	/// @param transport Transport to register with.
-	explicit RpcClientUSubscription::RpcClientUSubscription(
+	explicit RpcClientUSubscription(
 		std::shared_ptr<transport::UTransport> transport)
 		: transport_(std::move(transport)), uuri_builder_(USubscriptionUUriBuilder()) {}
 

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -50,7 +50,7 @@ struct RpcClientUSubscription : USubscription {
 	/// @param transport Transport to register with.
 	explicit RpcClientUSubscription(
 		std::shared_ptr<transport::UTransport> transport)
-		: transport_(std::move(transport)), uuri_builder_(USubscriptionUUriBuilder()) {}
+		: transport_(std::move(transport)) {}
 
 
 	/// @brief Destructor

--- a/src/client/usubscription/v3/RequestBuilder.cpp
+++ b/src/client/usubscription/v3/RequestBuilder.cpp
@@ -1,4 +1,5 @@
 #include <uprotocol/core/usubscription/v3/usubscription.pb.h>
+#include <iostream>
 #include "up-cpp/client/usubscription/v3/RequestBuilder.h"
 
 namespace uprotocol::core::usubscription::v3 {
@@ -10,6 +11,11 @@ SubscriptionRequest RequestBuilder::buildSubscriptionRequest(
 		options_.when_expire,
 		options_.subscription_details,
 		options_.sample_period_ms);
+	if (options_.permission_level.has_value()) {
+		std::cout << "PERMISSION LEVEL:" << options_.permission_level.value()<<std::endl;
+	} else {
+		std::cout << "no when_expire" << std::endl;
+	}
 
 	return utils::ProtoConverter::BuildSubscriptionRequest(
 		topic, attributes);

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -19,7 +19,6 @@
 #include <utility>
 
 #include "up-cpp/communication/RpcClient.h"
-#include "up-cpp/transport/UTransport.h"
 
 constexpr uint16_t RESOURCE_ID_SUBSCRIBE = 0x0001;
 // TODO(lennart) see default_call_options() for the request in Rust
@@ -47,7 +46,7 @@ RpcClientUSubscription::subscribe(
 
 	if (!message_or_status.has_value()) {
 		return ResponseOrStatus<SubscriptionResponse>(
-		    utils::Unexpected<v1::UStatus>(std::move(message_or_status.error())));
+		    utils::Unexpected<v1::UStatus>(message_or_status.error()));
 	}
 
 	SubscriptionResponse subscription_response;
@@ -56,7 +55,7 @@ RpcClientUSubscription::subscribe(
 	if (subscription_response.topic().SerializeAsString() !=
 	    subscription_request.topic().SerializeAsString()) {
 		return ResponseOrStatus<SubscriptionResponse>(
-			utils::Unexpected<v1::UStatus>(std::move(message_or_status.error())));
+			utils::Unexpected<v1::UStatus>(message_or_status.error()));
 	}
 
 	return ResponseOrStatus<SubscriptionResponse>(std::move(subscription_response));

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -24,7 +24,7 @@
 constexpr uint16_t RESOURCE_ID_SUBSCRIBE = 0x0001;
 // TODO(lennart) see default_call_options() for the request in Rust
 constexpr auto SUBSCRIPTION_REQUEST_TTL =
-    std::chrono::milliseconds(0x0800);  // TODO(lennart) change time
+    std::chrono::milliseconds(0x8000);  // TODO(lennart) change time
 auto priority = uprotocol::v1::UPriority::UPRIORITY_CS4;  // MUST be >= 4
 
 namespace uprotocol::core::usubscription::v3 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -86,6 +86,7 @@ add_coverage_test("ConsumerTest" coverage/client/usubscription/v3/ConsumerTest.c
 
 # core
 add_coverage_test("RpcClientUSubscriptionTest" coverage/client/usubscription/v3/RpcClientUSubscriptionTest.cpp)
+add_coverage_test("RequestBuilderTest" coverage/client/usubscription/v3/RequestBuilderTest.cpp)
 
 ########################## EXTRAS #############################################
 add_extra_test("PublisherSubscriberTest" extra/PublisherSubscriberTest.cpp)

--- a/test/coverage/client/usubscription/v3/RequestBuilderTest.cpp
+++ b/test/coverage/client/usubscription/v3/RequestBuilderTest.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include "up-cpp/client/usubscription/v3/RequestBuilder.h"
+#include <uprotocol/core/usubscription/v3/usubscription.pb.h>
+#include <optional>
+#include <chrono>
+#include <google/protobuf/any.pb.h>
+
+namespace uprotocol::core::usubscription::v3 {
+
+class RequestBuilderTest : public ::testing::Test {
+protected:
+    RequestBuilder builder_;
+    USubscriptionOptions options_;
+
+    void SetUp() override {
+        options_.permission_level = 1;
+        options_.token = "sample_token";
+        options_.when_expire = std::chrono::system_clock::now() + std::chrono::hours(1);
+        options_.sample_period_ms = std::chrono::milliseconds(1000);
+        options_.subscriber_details = google::protobuf::Any(); 
+        options_.subscription_details = google::protobuf::Any();
+        
+        RequestBuilder builder(options_);
+    }
+    void TearDown() override {}
+
+    // Run once per execution of the test application.
+	// Used for setup of all tests. Has access to this instance.
+	RequestBuilderTest() = default;
+
+    // Run once per execution of the test application.
+	// Used only for global setup outside of tests.
+	static void SetUpTestSuite() {}
+	static void TearDownTestSuite() {}
+
+public:
+	~RequestBuilderTest() override = default;
+};
+
+TEST_F(RequestBuilderTest, BuildSubscriptionRequestWithOptions) {
+    v1::UUri topic;
+
+    SubscriptionRequest request = builder_.buildSubscriptionRequest(topic);
+
+    // Verify the attributes in the request
+    // TODO(lennart) did not find appropriate member to check the remaining attributes
+    EXPECT_EQ(request.topic().SerializeAsString(), topic.SerializeAsString());
+    EXPECT_EQ(request.attributes().has_expire(), options_.when_expire.has_value());
+    // EXPECT_EQ(request.attributes().subscription_details().SerializeAsString(), options_.subscription_details->SerializeAsString());
+    EXPECT_EQ(request.attributes().sample_period_ms(), options_.sample_period_ms.value().count());
+    // EXPECT_EQ(request.attributes().permission_level(), options_.permission_level.value());
+    // EXPECT_EQ(request.attributes().token(), options_.token.value());
+    // EXPECT_EQ(request.attributes().subscriber_details().SerializeAsString(), options_.subscriber_details->SerializeAsString());
+}
+
+} // namespace uprotocol::core::usubscription::v3

--- a/test/coverage/client/usubscription/v3/RpcClientUSubscriptionTest.cpp
+++ b/test/coverage/client/usubscription/v3/RpcClientUSubscriptionTest.cpp
@@ -14,8 +14,6 @@
 #include <up-cpp/client/usubscription/v3/RpcClientUSubscription.h>
 #include <up-cpp/communication/NotificationSource.h>
 
-#include <string>
-
 #include "UTransportMock.h"
 
 namespace {


### PR DESCRIPTION
Unfortunatly I did not find appropiate member functions in protobuf to check all attributes assigned by building the request. 
Also did some minor changes that were asked from clang-tidy for cleaning up the code. Better check these before merging.