### PR TITLE
Rpc subscription client max

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,9 @@ file(GLOB_RECURSE SRC_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 add_library(${PROJECT_NAME} ${SRC_FILES}
 		src/client/usubscription/v3/RpcClientUSubscription.cpp
 		include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
-		include/up-cpp/client/usubscription/v3/USubscription.h)
+		include/up-cpp/client/usubscription/v3/USubscription.h
+		src/client/usubscription/v3/USubscriptionUUriBuilder.cpp
+		include/up-cpp/client/usubscription/v3/USubscriptionUUriBuilder.h)
 add_library(up-cpp::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,10 @@ endif()
 
 file(GLOB_RECURSE SRC_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 
-add_library(${PROJECT_NAME} ${SRC_FILES})
+add_library(${PROJECT_NAME} ${SRC_FILES}
+		src/client/usubscription/v3/RpcClientUSubscription.cpp
+		include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+		include/up-cpp/client/usubscription/v3/USubscription.h)
 add_library(up-cpp::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,12 +48,7 @@ endif()
 
 file(GLOB_RECURSE SRC_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 
-add_library(${PROJECT_NAME} ${SRC_FILES}
-		src/client/usubscription/v3/RpcClientUSubscription.cpp
-		include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
-		include/up-cpp/client/usubscription/v3/USubscription.h
-		src/client/usubscription/v3/USubscriptionUUriBuilder.cpp
-		include/up-cpp/client/usubscription/v3/USubscriptionUUriBuilder.h)
+add_library(${PROJECT_NAME} ${SRC_FILES})
 add_library(up-cpp::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME}

--- a/include/up-cpp/client/usubscription/v3/RequestBuilder.h
+++ b/include/up-cpp/client/usubscription/v3/RequestBuilder.h
@@ -1,6 +1,8 @@
 #ifndef REQUESTBUILDER_H
 #define REQUESTBUILDER_H
 #include <up-cpp/utils/ProtoConverter.h>
+
+#include <utility>
 #include "up-cpp/client/usubscription/v3/RpcClientUSubscription.h"
 
 
@@ -28,8 +30,8 @@ struct USubscriptionOptions {
 
 	struct RequestBuilder {
 		 explicit RequestBuilder(
-	        const USubscriptionOptions& options = {})
-			:options_(options){};
+	        USubscriptionOptions options = {})
+			:options_(std::move(options)){};
 
 		SubscriptionRequest buildSubscriptionRequest(const v1::UUri& topic) const;
 

--- a/include/up-cpp/client/usubscription/v3/RequestBuilder.h
+++ b/include/up-cpp/client/usubscription/v3/RequestBuilder.h
@@ -1,0 +1,42 @@
+#ifndef REQUESTBUILDER_H
+#define REQUESTBUILDER_H
+#include <up-cpp/utils/ProtoConverter.h>
+#include "up-cpp/client/usubscription/v3/RpcClientUSubscription.h"
+
+
+namespace uprotocol::core::usubscription::v3 {
+/**
+ * @struct USubscriptionOptions
+ * @brief Additional details for uSubscription service.
+ *
+ * Each member represents an optional parameter for the uSubscription service.
+ */
+struct USubscriptionOptions {
+	/// Permission level of the subscription request
+	std::optional<uint32_t> permission_level;
+	/// TAP token for access.
+	std::optional<std::string> token;
+	/// Expiration time of the subscription.
+	std::optional<std::chrono::system_clock::time_point> when_expire;
+	/// Sample period for the subscription messages in milliseconds.
+	std::optional<std::chrono::milliseconds> sample_period_ms;
+	/// Details of the subscriber.
+	std::optional<google::protobuf::Any> subscriber_details;
+	/// Details of the subscription.
+	std::optional<google::protobuf::Any> subscription_details;
+};
+
+	struct RequestBuilder {
+		 explicit RequestBuilder(
+	        const USubscriptionOptions& options)
+			:options_(options){};
+
+		SubscriptionRequest buildSubscriptionRequest(const v1::UUri& topic) const;
+
+		UnsubscribeRequest buildUnsubscribeRequest(const v1::UUri& topic);
+	private:
+		USubscriptionOptions options_;
+	};
+
+} // namespace uprotocol::core::usubscription::v3
+#endif //REQUESTBUILDER_H

--- a/include/up-cpp/client/usubscription/v3/RequestBuilder.h
+++ b/include/up-cpp/client/usubscription/v3/RequestBuilder.h
@@ -3,7 +3,6 @@
 #include <up-cpp/utils/ProtoConverter.h>
 
 #include <utility>
-#include "up-cpp/client/usubscription/v3/RpcClientUSubscription.h"
 
 
 namespace uprotocol::core::usubscription::v3 {
@@ -35,7 +34,7 @@ struct USubscriptionOptions {
 
 		SubscriptionRequest buildSubscriptionRequest(const v1::UUri& topic) const;
 
-		UnsubscribeRequest buildUnsubscribeRequest(const v1::UUri& topic);
+		static UnsubscribeRequest buildUnsubscribeRequest(const v1::UUri& topic);
 	private:
 		USubscriptionOptions options_;
 	};

--- a/include/up-cpp/client/usubscription/v3/RequestBuilder.h
+++ b/include/up-cpp/client/usubscription/v3/RequestBuilder.h
@@ -28,7 +28,7 @@ struct USubscriptionOptions {
 
 	struct RequestBuilder {
 		 explicit RequestBuilder(
-	        const USubscriptionOptions& options)
+	        const USubscriptionOptions& options = {})
 			:options_(options){};
 
 		SubscriptionRequest buildSubscriptionRequest(const v1::UUri& topic) const;

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -40,38 +40,20 @@ struct RpcClientUSubscription : USubscription {
 	using ListenCallback = transport::UTransport::ListenCallback;
 	using ListenHandle = transport::UTransport::ListenHandle;
 
-	/// @brief Create a subscription
-	///
-	/// @param transport Transport to register with.
-	/// @param subscription_topic Topic to subscribe to.
-	/// @param callback Function that is called when publish message is
-	/// received.
-	/// @param priority Priority of the subscription request.
-	/// @param subscribe_request_ttl Time to live for the subscription request.
-	/// @param rpc_client_usubscription_options Additional details for
-	/// uSubscription service.
-	// [[nodiscard]] static RpcClientUSubscriptionOrStatus create(
-	//     std::shared_ptr<transport::UTransport> transport,
-	//     const v1::UUri& subscription_topic, ListenCallback&& callback,
-	//     RpcClientUSubscriptionOptions rpc_client_usubscription_options);
-
 	/// @brief Subscribe to the topic
 	///
 	utils::Expected<SubscriptionResponse, v1::UStatus> subscribe(
 	    const SubscriptionRequest& subscription_request) override;
 
-	/// @brief Destructor
-	~RpcClientUSubscription() override = default;
-
-	/// This section for test code only delete later
-
-	// protected:
 	/// @brief Constructor
 	///
 	/// @param transport Transport to register with.
-	/// @param subscriber_details Additional details about the subscriber.
 	explicit RpcClientUSubscription(
 	    std::shared_ptr<transport::UTransport> transport);
+
+	/// @brief Destructor
+	~RpcClientUSubscription() override = default;
+
 
 private:
 	// Transport
@@ -79,14 +61,6 @@ private:
 
 	// URI info about the uSubscription service
 	USubscriptionUUriBuilder uuri_builder_;
-
-	// Allow the protected constructor for this class to be used in make_unique
-	// inside of create()
-	// friend std::unique_ptr<RpcClientUSubscription> std::make_unique<
-	//     RpcClientUSubscription, std::shared_ptr<transport::UTransport>,
-	//     const v1::UUri, RpcClientUSubscriptionOptions>(
-	//     std::shared_ptr<uprotocol::transport::UTransport>&&, const v1::UUri&&,
-	//     RpcClientUSubscriptionOptions&&);
 };
 
 }  // namespace uprotocol::core::usubscription::v3

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -1,89 +1,218 @@
+// SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #ifndef RPCCLIENTUSUBSCRIPTION_H
 #define RPCCLIENTUSUBSCRIPTION_H
 
+#include <up-cpp/communication/NotificationSink.h>
+#include <up-cpp/communication/RpcClient.h>
+#include <up-cpp/communication/Subscriber.h>
+#include <up-cpp/datamodel/builder/Payload.h>
+#include <up-cpp/utils/ProtoConverter.h>
 #include <uprotocol/core/usubscription/v3/usubscription.pb.h>
-#include "Consumer.h"
+#include <uprotocol/v1/umessage.pb.h>
 
-// #include "USubscription.h"
-#include "up-cpp/communication/RpcClient.h"
+#include <utility>
 
 namespace uprotocol::core::usubscription::v3 {
+using uprotocol::core::usubscription::v3::SubscriptionRequest;
+using uprotocol::core::usubscription::v3::UnsubscribeRequest;
+using uprotocol::core::usubscription::v3::Update;
+using uprotocol::core::usubscription::v3::uSubscription;
 
-struct RpcClientUSubscription : public uSubscription {
+/**
+ * @struct RpcClientUSubscriptionOptions
+ * @brief Additional details for uSubscription service.
+ *
+ * Each member represents an optional parameter for the uSubscription service.
+ */
+struct RpcClientUSubscriptionOptions {
+	/// Permission level of the subscription request
+	std::optional<uint32_t> permission_level;
+	/// TAP token for access.
+	std::optional<std::string> token;
+	/// Expiration time of the subscription.
+	std::optional<std::chrono::system_clock::time_point> when_expire;
+	/// Sample period for the subscription messages in milliseconds.
+	std::optional<std::chrono::milliseconds> sample_period_ms;
+	/// Details of the subscriber.
+	std::optional<google::protobuf::Any> subscriber_details;
+	/// Details of the subscription.
+	std::optional<google::protobuf::Any> subscription_details;
+};
+
+/// @struct uSubscriptionUUriBuilder
+/// @brief Structure to build uSubscription request URIs.
+///
+/// This structure is used to build URIs for uSubscription service. It uses the
+/// service options from uSubscription proto to set the authority name, ue_id,
+/// ue_version_major, and the notification topic resource ID in the URI.
+struct USubscriptionUUriBuilder {
+private:
+	/// URI for the uSubscription service
+	v1::UUri uri_;
+	/// Resource ID of the notification topic
+	uint32_t sink_resource_id_;
+
 public:
-	RpcClientUSubscription() = default;
-	~RpcClientUSubscription() override = default;
-	
-	explicit RpcClientUSubscription(std::unique_ptr<communication::RpcClient> rpc_client)
-		: rpc_client_(std::move(rpc_client)){};
+	/// @brief Constructor for USubscriptionUUriBuilder.
+	USubscriptionUUriBuilder() {
+		// Get the service descriptor
+		const google::protobuf::ServiceDescriptor* service =
+		    uSubscription::descriptor();
+		const auto& service_options = service->options();
 
-	
-	void Subscribe(google::protobuf::RpcController* controller,
-					const ::uprotocol::core::usubscription::v3::SubscriptionRequest* request,
-					::uprotocol::core::usubscription::v3::SubscriptionResponse* response,
-					::google::protobuf::Closure* done) override;
+		// Get the service options
+		const auto& service_name =
+		    service_options.GetExtension(uprotocol::service_name);
+		const auto& service_version_major =
+		    service_options.GetExtension(uprotocol::service_version_major);
+		const auto& service_id =
+		    service_options.GetExtension(uprotocol::service_id);
+		const auto& notification_topic =
+		    service_options.GetExtension(uprotocol::notification_topic, 0);
 
+		// Set the values in the URI
+		uri_.set_authority_name(service_name);
+		uri_.set_ue_id(service_id);
+		uri_.set_ue_version_major(service_version_major);
+		sink_resource_id_ = notification_topic.id();
+	}
+
+	/// @brief Get the URI with a specific resource ID.
+	///
+	/// @param resource_id The resource ID to set in the URI.
+	///
+	/// @return The URI with the specified resource ID.
+	v1::UUri getServiceUriWithResourceId(uint32_t resource_id) const {
+		v1::UUri uri = uri_;  // Copy the base URI
+		uri.set_resource_id(resource_id);
+		return uri;
+	}
+
+	/// @brief Get the notification URI.
+	///
+	/// @return The notification URI.
+	v1::UUri getNotificationUri() const {
+		v1::UUri uri = uri_;  // Copy the base URI
+		uri.set_resource_id(sink_resource_id_);
+		return uri;
+	}
+};
+
+/// @brief Interface for uEntities to create subscriptions.
+///
+/// Like all L3 client APIs, the RpcClientUSubscription is a wrapper on top of the
+/// L2 Communication APIs and USubscription service.
+struct RpcClientUSubscription : public uSubscription{
+	using RpcClientUSubscriptionOrStatus =
+	    utils::Expected<std::unique_ptr<RpcClientUSubscription>, v1::UStatus>;
+	using ListenCallback = transport::UTransport::ListenCallback;
+	using ListenHandle = transport::UTransport::ListenHandle;
+	using SubscriptionResponse = core::usubscription::v3::SubscriptionResponse;
+
+	/// @brief Create a subscription
+	///
+	/// @param transport Transport to register with.
+	/// @param subscription_topic Topic to subscribe to.
+	/// @param callback Function that is called when publish message is
+	/// received.
+	/// @param priority Priority of the subscription request.
+	/// @param subscribe_request_ttl Time to live for the subscription request.
+	/// @param rpc_client_usubscription_options Additional details for uSubscription service.
+	// [[nodiscard]] static RpcClientUSubscriptionOrStatus create(
+	//     std::shared_ptr<transport::UTransport> transport,
+	//     const v1::UUri& subscription_topic, ListenCallback&& callback,
+	//     v1::UPriority priority,
+	//     std::chrono::milliseconds subscription_request_ttl,
+	//     RpcClientUSubscriptionOptions rpc_client_usubscription_options);
+
+	/// @brief Unsubscribe from the topic and call uSubscription service to
+	/// close the subscription.
 	void Unsubscribe(google::protobuf::RpcController* controller,
-						const ::uprotocol::core::usubscription::v3::UnsubscribeRequest* request,
-						::uprotocol::core::usubscription::v3::UnsubscribeResponse* response,
-						::google::protobuf::Closure* done) override;
+		const ::uprotocol::core::usubscription::v3::UnsubscribeRequest* request,
+		::uprotocol::core::usubscription::v3::UnsubscribeResponse* response,
+		::google::protobuf::Closure* done) override;
 
-	void FetchSubscriptions(google::protobuf::RpcController* controller,
-									const ::uprotocol::core::usubscription::v3::FetchSubscriptionsRequest* request,
-									::uprotocol::core::usubscription::v3::FetchSubscriptionsResponse* response,
-									::google::protobuf::Closure* done) override;
+	/// @brief getter for subscription update
+	///
+	/// @return subscription update
+	Update getSubscriptionUpdate() const { return subscription_update_; }
 
-	void RegisterForNotifications(google::protobuf::RpcController* controller,
-											const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
-											::uprotocol::core::usubscription::v3::NotificationsResponse* response,
-											::google::protobuf::Closure* done) override;
+	/// @brief Destructor
+	~RpcClientUSubscription() = default;
 
-	void UnregisterForNotifications(google::protobuf::RpcController* controller,
-											const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
-											::uprotocol::core::usubscription::v3::NotificationsResponse* response,
-											::google::protobuf::Closure* done) override;
+	/// This section for test code only delete later
 
-	void FetchSubscribers(google::protobuf::RpcController* controller,
-									const ::uprotocol::core::usubscription::v3::FetchSubscribersRequest* request,
-									::uprotocol::core::usubscription::v3::FetchSubscribersResponse* response,
-									::google::protobuf::Closure* done) override;
-
-	void Reset(google::protobuf::RpcController* controller,
-						const ::uprotocol::core::usubscription::v3::ResetRequest* request,
-						::uprotocol::core::usubscription::v3::ResetResponse* response,
-						::google::protobuf::Closure* done) override;
-
-// Backup
-	void default_call_option();
-
-	// SubscriptionResponse subscribe(const SubscriptionRequest& subscription_request);
-
-	// UnsubscribeResponse unsubscribe(const UnsubscribeRequest& unsubscribe_request);
-
-	// FetchSubscriptionsResponse fetch_subscriptions(const FetchSubscriptionsRequest& fetch_subscribers_request);
-
-	// NotificationsResponse register_for_notifications(const NotificationsRequest& register_notifications_request);
-
-	// NotificationsResponse unregister_for_notifications(const NotificationsRequest& unregister_notifications_request);
-
-	// FetchSubscribersResponse fetch_subscribers(const FetchSubscribersRequest& fetch_subscribers_request);
+protected:
+	/// @brief Constructor
+	///
+	/// @param transport Transport to register with.
+	/// @param subscriber_details Additional details about the subscriber.
+	RpcClientUSubscription(std::shared_ptr<transport::UTransport> transport,
+	         v1::UUri subscription_topic,
+	         RpcClientUSubscriptionOptions rpc_client_usubscription_options = {});
 
 private:
+	// Transport
+	std::shared_ptr<transport::UTransport> transport_;
+
+	// Topic to subscribe to
+	const v1::UUri subscription_topic_;
+	// Additional details about uSubscription service
+	RpcClientUSubscriptionOptions rpc_client_usubscription_options_;
+
+	// URI info about the uSubscription service
+	USubscriptionUUriBuilder uSubscriptionUUriBuilder_;
+
+	// Subscription updates
+	std::unique_ptr<communication::NotificationSink> noficationSinkHandle_;
+	Update subscription_update_;
+
 	// RPC request
 	std::unique_ptr<communication::RpcClient> rpc_client_;
 	communication::RpcClient::InvokeHandle rpc_handle_;
 	SubscriptionResponse subscription_response_;
-	
-	// Transport
-	std::shared_ptr<transport::UTransport> transport_;
-	
-	// URI info about the uSubscription service
-	client::usubscription::v3::USubscriptionUUriBuilder uSubscriptionUUriBuilder_;
-	
-	// Topic to subscribe to
-	const v1::UUri subscription_topic_;
+	UnsubscribeResponse unsubscribe_response_;
+
+	// L2 Subscriber details
+	std::unique_ptr<communication::Subscriber> subscriber_;
+
+	// Allow the protected constructor for this class to be used in make_unique
+	// inside of create()
+	friend std::unique_ptr<RpcClientUSubscription>
+	std::make_unique<RpcClientUSubscription, std::shared_ptr<transport::UTransport>,
+	                 const uprotocol::v1::UUri,
+	                 uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions>(
+	    std::shared_ptr<uprotocol::transport::UTransport>&&,
+	    const uprotocol::v1::UUri&&,
+	    uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions&&);
+
+	/// @brief Build SubscriptionRequest for subscription request
+	SubscriptionRequest buildSubscriptionRequest();
+
+	/// @brief  Build UnsubscriptionRequest for unsubscription request
+	UnsubscribeRequest buildUnsubscriptionRequest();
+
+	/// @brief Create a notification sink to receive subscription updates
+	v1::UStatus createNotificationSink();
+
+	/// @brief Subscribe to the topic
+	///
+	void Subscribe(google::protobuf::RpcController* controller,
+		const ::uprotocol::core::usubscription::v3::SubscriptionRequest* request,
+		::uprotocol::core::usubscription::v3::SubscriptionResponse* response,
+		::google::protobuf::Closure* done) override;
 };
 
-} // namespace uprotocol::core::usubscription::v3
+}  // namespace uprotocol::core::usubscription::v3
 
-#endif //RPCCLIENTUSUBSCRIPTION_H
+#endif  // RPCCLIENTUSUBSCRIPTION_H

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -14,20 +14,18 @@
 
 #include <up-cpp/communication/NotificationSink.h>
 #include <up-cpp/communication/RpcClient.h>
-#include <up-cpp/communication/Subscriber.h>
 #include <up-cpp/datamodel/builder/Payload.h>
 #include <up-cpp/utils/ProtoConverter.h>
 #include <uprotocol/core/usubscription/v3/usubscription.pb.h>
-#include <uprotocol/v1/umessage.pb.h>
+#include <up-cpp/transport/UTransport.h>
 
-#include <utility>
 #include "up-cpp/client/usubscription/v3/USubscription.h"
 
 namespace uprotocol::core::usubscription::v3 {
-using uprotocol::core::usubscription::v3::SubscriptionRequest;
-using uprotocol::core::usubscription::v3::UnsubscribeRequest;
-using uprotocol::core::usubscription::v3::Update;
-using uprotocol::core::usubscription::v3::uSubscription;
+using v3::SubscriptionRequest;
+using v3::UnsubscribeRequest;
+using v3::Update;
+using v3::uSubscription;
 
 /**
  * @struct RpcClientUSubscriptionOptions
@@ -111,9 +109,9 @@ public:
 
 /// @brief Interface for uEntities to create subscriptions.
 ///
-/// Like all L3 client APIs, the RpcClientUSubscription is a wrapper on top of the
-/// L2 Communication APIs and USubscription service.
-struct RpcClientUSubscription : public USubscription{
+/// Like all L3 client APIs, the RpcClientUSubscription is a wrapper on top of
+/// the L2 Communication APIs and USubscription service.
+struct RpcClientUSubscription : USubscription {
 	using RpcClientUSubscriptionOrStatus =
 	    utils::Expected<std::unique_ptr<RpcClientUSubscription>, v1::UStatus>;
 	using ListenCallback = transport::UTransport::ListenCallback;
@@ -127,7 +125,8 @@ struct RpcClientUSubscription : public USubscription{
 	/// received.
 	/// @param priority Priority of the subscription request.
 	/// @param subscribe_request_ttl Time to live for the subscription request.
-	/// @param rpc_client_usubscription_options Additional details for uSubscription service.
+	/// @param rpc_client_usubscription_options Additional details for
+	/// uSubscription service.
 	// [[nodiscard]] static RpcClientUSubscriptionOrStatus create(
 	//     std::shared_ptr<transport::UTransport> transport,
 	//     const v1::UUri& subscription_topic, ListenCallback&& callback,
@@ -135,43 +134,53 @@ struct RpcClientUSubscription : public USubscription{
 
 	/// @brief Subscribe to the topic
 	///
-	utils::Expected<SubscriptionResponse, v1::UStatus> subscribe(const SubscriptionRequest& subscription_request) override;
+	utils::Expected<SubscriptionResponse, v1::UStatus> subscribe(
+	    const SubscriptionRequest& subscription_request) override;
 	// void subscribe(google::protobuf::RpcController* controller,
-	// 	const ::uprotocol::core::usubscription::v3::SubscriptionRequest* request,
+	// 	const ::uprotocol::core::usubscription::v3::SubscriptionRequest*
+	// request,
 	// 	::uprotocol::core::usubscription::v3::SubscriptionResponse* response,
 	// 	::google::protobuf::Closure* done) override;
-	
+
 	/// @brief Unsubscribe from the topic and call uSubscription service to
 	/// close the subscription.
 	// void Unsubscribe(google::protobuf::RpcController* controller,
 	// 	const ::uprotocol::core::usubscription::v3::UnsubscribeRequest* request,
 	// 	::uprotocol::core::usubscription::v3::UnsubscribeResponse* response,
 	// 	::google::protobuf::Closure* done) override;
-	
-	// /// @brief Fetch all subscriptions for a given topic or subscriber contained inside a [`FetchSubscriptionsRequest`]
-	// void FetchSubscriptions(google::protobuf::RpcController* controller,
-	// 	const ::uprotocol::core::usubscription::v3::FetchSubscriptionsRequest* request,
-	// 	::uprotocol::core::usubscription::v3::FetchSubscriptionsResponse* response,
+
+	// /// @brief Fetch all subscriptions for a given topic or subscriber
+	// contained inside a [`FetchSubscriptionsRequest`] void
+	// FetchSubscriptions(google::protobuf::RpcController* controller, 	const
+	// ::uprotocol::core::usubscription::v3::FetchSubscriptionsRequest* request,
+	// 	::uprotocol::core::usubscription::v3::FetchSubscriptionsResponse*
+	// response,
 	// 	::google::protobuf::Closure* done) override;
-	
-	// /// @brief Register for notifications relevant to a given topic inside a [`NotificationsRequest`]
-    // /// changing in subscription status.
-	// void RegisterForNotifications(google::protobuf::RpcController* controller,
-	// 	const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
-	// 	::uprotocol::core::usubscription::v3::NotificationsResponse* response,
-	// 	::google::protobuf::Closure* done) override;
-	
-	// /// @brief Unregister for notifications relevant to a given topic inside a [`NotificationsRequest`]
-    // /// changing in subscription status.
-	// void UnregisterForNotifications(google::protobuf::RpcController* controller,
-	// 	const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
+
+	// /// @brief Register for notifications relevant to a given topic inside a
+	// [`NotificationsRequest`]
+	// /// changing in subscription status.
+	// void RegisterForNotifications(google::protobuf::RpcController*
+	// controller, 	const
+	// ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
 	// 	::uprotocol::core::usubscription::v3::NotificationsResponse* response,
 	// 	::google::protobuf::Closure* done) override;
 
-	// /// @brief Fetch a list of subscribers that are currently subscribed to a given topic in a [`FetchSubscribersRequest`]	
-	// void FetchSubscribers(google::protobuf::RpcController* controller,
-	// 	const ::uprotocol::core::usubscription::v3::FetchSubscribersRequest* request,
-	// 	::uprotocol::core::usubscription::v3::FetchSubscribersResponse* response,
+	// /// @brief Unregister for notifications relevant to a given topic inside
+	// a [`NotificationsRequest`]
+	// /// changing in subscription status.
+	// void UnregisterForNotifications(google::protobuf::RpcController*
+	// controller, 	const
+	// ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
+	// 	::uprotocol::core::usubscription::v3::NotificationsResponse* response,
+	// 	::google::protobuf::Closure* done) override;
+
+	// /// @brief Fetch a list of subscribers that are currently subscribed to a
+	// given topic in a [`FetchSubscribersRequest`] void
+	// FetchSubscribers(google::protobuf::RpcController* controller, 	const
+	// ::uprotocol::core::usubscription::v3::FetchSubscribersRequest* request,
+	// 	::uprotocol::core::usubscription::v3::FetchSubscribersResponse*
+	// response,
 	// 	::google::protobuf::Closure* done) override;
 
 	/// @brief Destructor
@@ -179,13 +188,14 @@ struct RpcClientUSubscription : public USubscription{
 
 	/// This section for test code only delete later
 
-// protected:
+	// protected:
 	/// @brief Constructor
 	///
 	/// @param transport Transport to register with.
 	/// @param subscriber_details Additional details about the subscriber.
-	explicit RpcClientUSubscription(std::shared_ptr<transport::UTransport> transport,
-	         RpcClientUSubscriptionOptions rpc_client_usubscription_options = {});
+	explicit RpcClientUSubscription(
+	    std::shared_ptr<transport::UTransport> transport,
+	    RpcClientUSubscriptionOptions rpc_client_usubscription_options = {});
 
 private:
 	// Transport
@@ -198,27 +208,24 @@ private:
 	RpcClientUSubscriptionOptions rpc_client_usubscription_options_;
 
 	// URI info about the uSubscription service
-	USubscriptionUUriBuilder uSubscriptionUUriBuilder_;
+	USubscriptionUUriBuilder uuri_builder_;
 
 	// Allow the protected constructor for this class to be used in make_unique
 	// inside of create()
-	friend std::unique_ptr<RpcClientUSubscription>
-	std::make_unique<RpcClientUSubscription, std::shared_ptr<transport::UTransport>,
-	                 const uprotocol::v1::UUri,
-	                 uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions>(
-	    std::shared_ptr<uprotocol::transport::UTransport>&&,
-	    const uprotocol::v1::UUri&&,
-	    uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions&&);
+	// friend std::unique_ptr<RpcClientUSubscription> std::make_unique<
+	//     RpcClientUSubscription, std::shared_ptr<transport::UTransport>,
+	//     const v1::UUri, RpcClientUSubscriptionOptions>(
+	//     std::shared_ptr<uprotocol::transport::UTransport>&&, const v1::UUri&&,
+	//     RpcClientUSubscriptionOptions&&);
 
 	/// @brief Build SubscriptionRequest for subscription request
 	SubscriptionRequest buildSubscriptionRequest();
-
-	/// @brief  Build UnsubscriptionRequest for unsubscription request
-	UnsubscribeRequest buildUnsubscriptionRequest();
-
-	/// @brief Create a notification sink to receive subscription updates
-	v1::UStatus createNotificationSink();
-
+	//
+	// /// @brief  Build UnsubscriptionRequest for unsubscription request
+	// UnsubscribeRequest buildUnsubscriptionRequest();
+	//
+	// /// @brief Create a notification sink to receive subscription updates
+	// v1::UStatus createNotificationSink();
 };
 
 }  // namespace uprotocol::core::usubscription::v3

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -112,6 +112,7 @@ private:
 	//     std::shared_ptr<uprotocol::transport::UTransport>&&, const v1::UUri&&,
 	//     RpcClientUSubscriptionOptions&&);
 
+public:
 	/// @brief Build SubscriptionRequest for subscription request
 	SubscriptionRequest buildSubscriptionRequest(const v1::UUri& subscription_topic);
 	//

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -127,12 +127,10 @@ struct RpcClientUSubscription : public uSubscription{
 	/// @param priority Priority of the subscription request.
 	/// @param subscribe_request_ttl Time to live for the subscription request.
 	/// @param rpc_client_usubscription_options Additional details for uSubscription service.
-	// [[nodiscard]] static RpcClientUSubscriptionOrStatus create(
-	//     std::shared_ptr<transport::UTransport> transport,
-	//     const v1::UUri& subscription_topic, ListenCallback&& callback,
-	//     v1::UPriority priority,
-	//     std::chrono::milliseconds subscription_request_ttl,
-	//     RpcClientUSubscriptionOptions rpc_client_usubscription_options);
+	[[nodiscard]] static RpcClientUSubscriptionOrStatus create(
+	    std::shared_ptr<transport::UTransport> transport,
+	    const v1::UUri& subscription_topic, ListenCallback&& callback,
+	    RpcClientUSubscriptionOptions rpc_client_usubscription_options);
 
 	/// @brief Unsubscribe from the topic and call uSubscription service to
 	/// close the subscription.

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -1,0 +1,41 @@
+//
+// Created by max on 28.04.25.
+//
+
+#ifndef RPCCLIENTUSUBSCRIPTION_H
+#define RPCCLIENTUSUBSCRIPTION_H
+
+#include <uprotocol/core/usubscription/v3/usubscription.pb.h>
+
+#include "USubscription.h"
+#include "up-cpp/communication/RpcClient.h"
+
+namespace uprotocol::core::usubscription::v3 {
+
+struct RpcClientUSubscription : USubscription {
+
+	explicit RpcClientUSubscription(std::unique_ptr<communication::RpcClient> client)
+		: client_(std::move(client)){};
+
+	void default_call_option();
+
+	SubscriptionResponse subscribe(const SubscriptionRequest& subscription_request) override;
+
+	UnsubscribeResponse unsubscribe(const UnsubscribeRequest& unsubscribe_request) override;
+
+	FetchSubscriptionsResponse fetch_subscriptions(const FetchSubscriptionsRequest& fetch_subscribers_request) override;
+
+	NotificationsResponse register_for_notifications(const NotificationsRequest& register_notifications_request) override;
+
+	NotificationsResponse unregister_for_notifications(const NotificationsRequest& unregister_notifications_request) override;
+
+	FetchSubscribersResponse fetch_subscribers(const FetchSubscribersRequest& fetch_subscribers_request) override;
+
+private:
+	std::unique_ptr<communication::RpcClient> client_;
+
+};
+
+} // namespace uprotocol::core::usubscription::v3
+
+#endif //RPCCLIENTUSUBSCRIPTION_H

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -21,6 +21,7 @@
 #include <uprotocol/v1/umessage.pb.h>
 
 #include <utility>
+#include "up-cpp/client/usubscription/v3/USubscription.h"
 
 namespace uprotocol::core::usubscription::v3 {
 using uprotocol::core::usubscription::v3::SubscriptionRequest;
@@ -112,7 +113,7 @@ public:
 ///
 /// Like all L3 client APIs, the RpcClientUSubscription is a wrapper on top of the
 /// L2 Communication APIs and USubscription service.
-struct RpcClientUSubscription : public uSubscription{
+struct RpcClientUSubscription : public USubscription{
 	using RpcClientUSubscriptionOrStatus =
 	    utils::Expected<std::unique_ptr<RpcClientUSubscription>, v1::UStatus>;
 	using ListenCallback = transport::UTransport::ListenCallback;
@@ -127,61 +128,63 @@ struct RpcClientUSubscription : public uSubscription{
 	/// @param priority Priority of the subscription request.
 	/// @param subscribe_request_ttl Time to live for the subscription request.
 	/// @param rpc_client_usubscription_options Additional details for uSubscription service.
-	[[nodiscard]] static RpcClientUSubscriptionOrStatus create(
-	    std::shared_ptr<transport::UTransport> transport,
-	    const v1::UUri& subscription_topic, ListenCallback&& callback,
-	    RpcClientUSubscriptionOptions rpc_client_usubscription_options);
+	// [[nodiscard]] static RpcClientUSubscriptionOrStatus create(
+	//     std::shared_ptr<transport::UTransport> transport,
+	//     const v1::UUri& subscription_topic, ListenCallback&& callback,
+	//     RpcClientUSubscriptionOptions rpc_client_usubscription_options);
 
+	/// @brief Subscribe to the topic
+	///
+	utils::Expected<SubscriptionResponse, v1::UStatus> subscribe(const SubscriptionRequest& subscription_request) override;
+	// void subscribe(google::protobuf::RpcController* controller,
+	// 	const ::uprotocol::core::usubscription::v3::SubscriptionRequest* request,
+	// 	::uprotocol::core::usubscription::v3::SubscriptionResponse* response,
+	// 	::google::protobuf::Closure* done) override;
+	
 	/// @brief Unsubscribe from the topic and call uSubscription service to
 	/// close the subscription.
-	void Unsubscribe(google::protobuf::RpcController* controller,
-		const ::uprotocol::core::usubscription::v3::UnsubscribeRequest* request,
-		::uprotocol::core::usubscription::v3::UnsubscribeResponse* response,
-		::google::protobuf::Closure* done) override;
+	// void Unsubscribe(google::protobuf::RpcController* controller,
+	// 	const ::uprotocol::core::usubscription::v3::UnsubscribeRequest* request,
+	// 	::uprotocol::core::usubscription::v3::UnsubscribeResponse* response,
+	// 	::google::protobuf::Closure* done) override;
 	
-	/// @brief Fetch all subscriptions for a given topic or subscriber contained inside a [`FetchSubscriptionsRequest`]
-	void FetchSubscriptions(google::protobuf::RpcController* controller,
-		const ::uprotocol::core::usubscription::v3::FetchSubscriptionsRequest* request,
-		::uprotocol::core::usubscription::v3::FetchSubscriptionsResponse* response,
-		::google::protobuf::Closure* done) override;
+	// /// @brief Fetch all subscriptions for a given topic or subscriber contained inside a [`FetchSubscriptionsRequest`]
+	// void FetchSubscriptions(google::protobuf::RpcController* controller,
+	// 	const ::uprotocol::core::usubscription::v3::FetchSubscriptionsRequest* request,
+	// 	::uprotocol::core::usubscription::v3::FetchSubscriptionsResponse* response,
+	// 	::google::protobuf::Closure* done) override;
 	
-	/// @brief Register for notifications relevant to a given topic inside a [`NotificationsRequest`]
-    /// changing in subscription status.
-	void RegisterForNotifications(google::protobuf::RpcController* controller,
-		const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
-		::uprotocol::core::usubscription::v3::NotificationsResponse* response,
-		::google::protobuf::Closure* done) override;
+	// /// @brief Register for notifications relevant to a given topic inside a [`NotificationsRequest`]
+    // /// changing in subscription status.
+	// void RegisterForNotifications(google::protobuf::RpcController* controller,
+	// 	const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
+	// 	::uprotocol::core::usubscription::v3::NotificationsResponse* response,
+	// 	::google::protobuf::Closure* done) override;
 	
-	/// @brief Unregister for notifications relevant to a given topic inside a [`NotificationsRequest`]
-    /// changing in subscription status.
-	void UnregisterForNotifications(google::protobuf::RpcController* controller,
-		const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
-		::uprotocol::core::usubscription::v3::NotificationsResponse* response,
-		::google::protobuf::Closure* done) override;
+	// /// @brief Unregister for notifications relevant to a given topic inside a [`NotificationsRequest`]
+    // /// changing in subscription status.
+	// void UnregisterForNotifications(google::protobuf::RpcController* controller,
+	// 	const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
+	// 	::uprotocol::core::usubscription::v3::NotificationsResponse* response,
+	// 	::google::protobuf::Closure* done) override;
 
-	/// @brief Fetch a list of subscribers that are currently subscribed to a given topic in a [`FetchSubscribersRequest`]	
-	void FetchSubscribers(google::protobuf::RpcController* controller,
-		const ::uprotocol::core::usubscription::v3::FetchSubscribersRequest* request,
-		::uprotocol::core::usubscription::v3::FetchSubscribersResponse* response,
-		::google::protobuf::Closure* done) override;
-
-	/// @brief getter for subscription update
-	///
-	/// @return subscription update
-	Update getSubscriptionUpdate() const { return subscription_update_; }
+	// /// @brief Fetch a list of subscribers that are currently subscribed to a given topic in a [`FetchSubscribersRequest`]	
+	// void FetchSubscribers(google::protobuf::RpcController* controller,
+	// 	const ::uprotocol::core::usubscription::v3::FetchSubscribersRequest* request,
+	// 	::uprotocol::core::usubscription::v3::FetchSubscribersResponse* response,
+	// 	::google::protobuf::Closure* done) override;
 
 	/// @brief Destructor
-	~RpcClientUSubscription() = default;
+	~RpcClientUSubscription() override = default;
 
 	/// This section for test code only delete later
 
-protected:
+// protected:
 	/// @brief Constructor
 	///
 	/// @param transport Transport to register with.
 	/// @param subscriber_details Additional details about the subscriber.
-	RpcClientUSubscription(std::shared_ptr<transport::UTransport> transport,
-	         v1::UUri subscription_topic,
+	explicit RpcClientUSubscription(std::shared_ptr<transport::UTransport> transport,
 	         RpcClientUSubscriptionOptions rpc_client_usubscription_options = {});
 
 private:
@@ -190,28 +193,12 @@ private:
 
 	// Topic to subscribe to
 	const v1::UUri subscription_topic_;
+
 	// Additional details about uSubscription service
 	RpcClientUSubscriptionOptions rpc_client_usubscription_options_;
 
 	// URI info about the uSubscription service
 	USubscriptionUUriBuilder uSubscriptionUUriBuilder_;
-
-	// Subscription updates
-	std::unique_ptr<communication::NotificationSink> noficationSinkHandle_;
-	Update subscription_update_;
-
-	// RPC request
-	std::unique_ptr<communication::RpcClient> rpc_client_;
-	communication::RpcClient::InvokeHandle rpc_handle_;
-
-	SubscriptionResponse subscription_response_;
-	UnsubscribeResponse unsubscribe_response_;
-	FetchSubscriptionsResponse fetch_subscription_response_;
-	NotificationsResponse notification_response_;
-	FetchSubscribersResponse fetch_subscribers_response_;
-
-	// L2 Subscriber details
-	std::unique_ptr<communication::Subscriber> subscriber_;
 
 	// Allow the protected constructor for this class to be used in make_unique
 	// inside of create()
@@ -232,12 +219,6 @@ private:
 	/// @brief Create a notification sink to receive subscription updates
 	v1::UStatus createNotificationSink();
 
-	/// @brief Subscribe to the topic
-	///
-	void Subscribe(google::protobuf::RpcController* controller,
-		const ::uprotocol::core::usubscription::v3::SubscriptionRequest* request,
-		::uprotocol::core::usubscription::v3::SubscriptionResponse* response,
-		::google::protobuf::Closure* done) override;
 };
 
 }  // namespace uprotocol::core::usubscription::v3

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -48,7 +48,7 @@ struct RpcClientUSubscription : USubscription {
 	/// @brief Constructor
 	///
 	/// @param transport Transport to register with.
-	explicit RpcClientUSubscription::RpcClientUSubscription(
+	explicit RpcClientUSubscription(
 		std::shared_ptr<transport::UTransport> transport)
 		: transport_(std::move(transport)), uuri_builder_(USubscriptionUUriBuilder()) {}
 

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -50,7 +50,7 @@ struct RpcClientUSubscription : USubscription {
 	/// @param transport Transport to register with.
 	explicit RpcClientUSubscription(
 		std::shared_ptr<transport::UTransport> transport)
-		: transport_(std::move(transport)), uuri_builder_(USubscriptionUUriBuilder()) {}
+		: transport_(std::move(transport)) {}
 
 
 	/// @brief Destructor

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -70,8 +70,8 @@ public:
 		const auto& service_options = service->options();
 
 		// Get the service options
-		const auto& service_name = "usubscription.local";
-		    // service_options.GetExtension(uprotocol::service_name);
+		const auto& service_name =
+		    service_options.GetExtension(uprotocol::service_name);
 		const auto& service_version_major =
 		    service_options.GetExtension(uprotocol::service_version_major);
 		const auto& service_id =

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -1,39 +1,87 @@
-//
-// Created by max on 28.04.25.
-//
-
 #ifndef RPCCLIENTUSUBSCRIPTION_H
 #define RPCCLIENTUSUBSCRIPTION_H
 
 #include <uprotocol/core/usubscription/v3/usubscription.pb.h>
+#include "Consumer.h"
 
-#include "USubscription.h"
+// #include "USubscription.h"
 #include "up-cpp/communication/RpcClient.h"
 
 namespace uprotocol::core::usubscription::v3 {
 
-struct RpcClientUSubscription : USubscription {
+struct RpcClientUSubscription : public uSubscription {
+public:
+	RpcClientUSubscription() = default;
+	~RpcClientUSubscription() override = default;
+	
+	explicit RpcClientUSubscription(std::unique_ptr<communication::RpcClient> rpc_client)
+		: rpc_client_(std::move(rpc_client)){};
 
-	explicit RpcClientUSubscription(std::unique_ptr<communication::RpcClient> client)
-		: client_(std::move(client)){};
+	
+	void Subscribe(google::protobuf::RpcController* controller,
+					const ::uprotocol::core::usubscription::v3::SubscriptionRequest* request,
+					::uprotocol::core::usubscription::v3::SubscriptionResponse* response,
+					::google::protobuf::Closure* done) override;
 
+	void Unsubscribe(google::protobuf::RpcController* controller,
+						const ::uprotocol::core::usubscription::v3::UnsubscribeRequest* request,
+						::uprotocol::core::usubscription::v3::UnsubscribeResponse* response,
+						::google::protobuf::Closure* done) override;
+
+	void FetchSubscriptions(google::protobuf::RpcController* controller,
+									const ::uprotocol::core::usubscription::v3::FetchSubscriptionsRequest* request,
+									::uprotocol::core::usubscription::v3::FetchSubscriptionsResponse* response,
+									::google::protobuf::Closure* done) override;
+
+	void RegisterForNotifications(google::protobuf::RpcController* controller,
+											const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
+											::uprotocol::core::usubscription::v3::NotificationsResponse* response,
+											::google::protobuf::Closure* done) override;
+
+	void UnregisterForNotifications(google::protobuf::RpcController* controller,
+											const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
+											::uprotocol::core::usubscription::v3::NotificationsResponse* response,
+											::google::protobuf::Closure* done) override;
+
+	void FetchSubscribers(google::protobuf::RpcController* controller,
+									const ::uprotocol::core::usubscription::v3::FetchSubscribersRequest* request,
+									::uprotocol::core::usubscription::v3::FetchSubscribersResponse* response,
+									::google::protobuf::Closure* done) override;
+
+	void Reset(google::protobuf::RpcController* controller,
+						const ::uprotocol::core::usubscription::v3::ResetRequest* request,
+						::uprotocol::core::usubscription::v3::ResetResponse* response,
+						::google::protobuf::Closure* done) override;
+
+// Backup
 	void default_call_option();
 
-	SubscriptionResponse subscribe(const SubscriptionRequest& subscription_request) override;
+	// SubscriptionResponse subscribe(const SubscriptionRequest& subscription_request);
 
-	UnsubscribeResponse unsubscribe(const UnsubscribeRequest& unsubscribe_request) override;
+	// UnsubscribeResponse unsubscribe(const UnsubscribeRequest& unsubscribe_request);
 
-	FetchSubscriptionsResponse fetch_subscriptions(const FetchSubscriptionsRequest& fetch_subscribers_request) override;
+	// FetchSubscriptionsResponse fetch_subscriptions(const FetchSubscriptionsRequest& fetch_subscribers_request);
 
-	NotificationsResponse register_for_notifications(const NotificationsRequest& register_notifications_request) override;
+	// NotificationsResponse register_for_notifications(const NotificationsRequest& register_notifications_request);
 
-	NotificationsResponse unregister_for_notifications(const NotificationsRequest& unregister_notifications_request) override;
+	// NotificationsResponse unregister_for_notifications(const NotificationsRequest& unregister_notifications_request);
 
-	FetchSubscribersResponse fetch_subscribers(const FetchSubscribersRequest& fetch_subscribers_request) override;
+	// FetchSubscribersResponse fetch_subscribers(const FetchSubscribersRequest& fetch_subscribers_request);
 
 private:
-	std::unique_ptr<communication::RpcClient> client_;
-
+	// RPC request
+	std::unique_ptr<communication::RpcClient> rpc_client_;
+	communication::RpcClient::InvokeHandle rpc_handle_;
+	SubscriptionResponse subscription_response_;
+	
+	// Transport
+	std::shared_ptr<transport::UTransport> transport_;
+	
+	// URI info about the uSubscription service
+	client::usubscription::v3::USubscriptionUUriBuilder uSubscriptionUUriBuilder_;
+	
+	// Topic to subscribe to
+	const v1::UUri subscription_topic_;
 };
 
 } // namespace uprotocol::core::usubscription::v3

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -70,8 +70,8 @@ public:
 		const auto& service_options = service->options();
 
 		// Get the service options
-		const auto& service_name =
-		    service_options.GetExtension(uprotocol::service_name);
+		const auto& service_name = "test.name";
+		    // service_options.GetExtension(uprotocol::service_name);
 		const auto& service_version_major =
 		    service_options.GetExtension(uprotocol::service_version_major);
 		const auto& service_id =

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -15,9 +15,9 @@
 #include <up-cpp/communication/NotificationSink.h>
 #include <up-cpp/communication/RpcClient.h>
 #include <up-cpp/datamodel/builder/Payload.h>
+#include <up-cpp/transport/UTransport.h>
 #include <up-cpp/utils/ProtoConverter.h>
 #include <uprotocol/core/usubscription/v3/usubscription.pb.h>
-#include <up-cpp/transport/UTransport.h>
 
 #include "up-cpp/client/usubscription/v3/USubscription.h"
 #include "up-cpp/client/usubscription/v3/USubscriptionUUriBuilder.h"
@@ -28,26 +28,6 @@ using v3::UnsubscribeRequest;
 using v3::Update;
 using v3::uSubscription;
 
-/**
- * @struct RpcClientUSubscriptionOptions
- * @brief Additional details for uSubscription service.
- *
- * Each member represents an optional parameter for the uSubscription service.
- */
-struct RpcClientUSubscriptionOptions {
-	/// Permission level of the subscription request
-	std::optional<uint32_t> permission_level;
-	/// TAP token for access.
-	std::optional<std::string> token;
-	/// Expiration time of the subscription.
-	std::optional<std::chrono::system_clock::time_point> when_expire;
-	/// Sample period for the subscription messages in milliseconds.
-	std::optional<std::chrono::milliseconds> sample_period_ms;
-	/// Details of the subscriber.
-	std::optional<google::protobuf::Any> subscriber_details;
-	/// Details of the subscription.
-	std::optional<google::protobuf::Any> subscription_details;
-};
 
 
 /// @brief Interface for uEntities to create subscriptions.
@@ -91,15 +71,11 @@ struct RpcClientUSubscription : USubscription {
 	/// @param transport Transport to register with.
 	/// @param subscriber_details Additional details about the subscriber.
 	explicit RpcClientUSubscription(
-	    std::shared_ptr<transport::UTransport> transport,
-	    RpcClientUSubscriptionOptions rpc_client_usubscription_options = {});
+	    std::shared_ptr<transport::UTransport> transport);
 
 private:
 	// Transport
 	std::shared_ptr<transport::UTransport> transport_;
-
-	// Additional details about uSubscription service
-	RpcClientUSubscriptionOptions rpc_client_usubscription_options_;
 
 	// URI info about the uSubscription service
 	USubscriptionUUriBuilder uuri_builder_;
@@ -111,16 +87,6 @@ private:
 	//     const v1::UUri, RpcClientUSubscriptionOptions>(
 	//     std::shared_ptr<uprotocol::transport::UTransport>&&, const v1::UUri&&,
 	//     RpcClientUSubscriptionOptions&&);
-
-public:
-	/// @brief Build SubscriptionRequest for subscription request
-	SubscriptionRequest buildSubscriptionRequest(const v1::UUri& subscription_topic);
-	//
-	// /// @brief  Build UnsubscriptionRequest for unsubscription request
-	// UnsubscribeRequest buildUnsubscriptionRequest();
-	//
-	// /// @brief Create a notification sink to receive subscription updates
-	// v1::UStatus createNotificationSink();
 };
 
 }  // namespace uprotocol::core::usubscription::v3

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -117,7 +117,6 @@ struct RpcClientUSubscription : public uSubscription{
 	    utils::Expected<std::unique_ptr<RpcClientUSubscription>, v1::UStatus>;
 	using ListenCallback = transport::UTransport::ListenCallback;
 	using ListenHandle = transport::UTransport::ListenHandle;
-	using SubscriptionResponse = core::usubscription::v3::SubscriptionResponse;
 
 	/// @brief Create a subscription
 	///
@@ -140,6 +139,32 @@ struct RpcClientUSubscription : public uSubscription{
 	void Unsubscribe(google::protobuf::RpcController* controller,
 		const ::uprotocol::core::usubscription::v3::UnsubscribeRequest* request,
 		::uprotocol::core::usubscription::v3::UnsubscribeResponse* response,
+		::google::protobuf::Closure* done) override;
+	
+	/// @brief Fetch all subscriptions for a given topic or subscriber contained inside a [`FetchSubscriptionsRequest`]
+	void FetchSubscriptions(google::protobuf::RpcController* controller,
+		const ::uprotocol::core::usubscription::v3::FetchSubscriptionsRequest* request,
+		::uprotocol::core::usubscription::v3::FetchSubscriptionsResponse* response,
+		::google::protobuf::Closure* done) override;
+	
+	/// @brief Register for notifications relevant to a given topic inside a [`NotificationsRequest`]
+    /// changing in subscription status.
+	void RegisterForNotifications(google::protobuf::RpcController* controller,
+		const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
+		::uprotocol::core::usubscription::v3::NotificationsResponse* response,
+		::google::protobuf::Closure* done) override;
+	
+	/// @brief Unregister for notifications relevant to a given topic inside a [`NotificationsRequest`]
+    /// changing in subscription status.
+	void UnregisterForNotifications(google::protobuf::RpcController* controller,
+		const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
+		::uprotocol::core::usubscription::v3::NotificationsResponse* response,
+		::google::protobuf::Closure* done) override;
+
+	/// @brief Fetch a list of subscribers that are currently subscribed to a given topic in a [`FetchSubscribersRequest`]	
+	void FetchSubscribers(google::protobuf::RpcController* controller,
+		const ::uprotocol::core::usubscription::v3::FetchSubscribersRequest* request,
+		::uprotocol::core::usubscription::v3::FetchSubscribersResponse* response,
 		::google::protobuf::Closure* done) override;
 
 	/// @brief getter for subscription update
@@ -180,8 +205,12 @@ private:
 	// RPC request
 	std::unique_ptr<communication::RpcClient> rpc_client_;
 	communication::RpcClient::InvokeHandle rpc_handle_;
+
 	SubscriptionResponse subscription_response_;
 	UnsubscribeResponse unsubscribe_response_;
+	FetchSubscriptionsResponse fetch_subscription_response_;
+	NotificationsResponse notification_response_;
+	FetchSubscribersResponse fetch_subscribers_response_;
 
 	// L2 Subscriber details
 	std::unique_ptr<communication::Subscriber> subscriber_;

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -48,8 +48,10 @@ struct RpcClientUSubscription : USubscription {
 	/// @brief Constructor
 	///
 	/// @param transport Transport to register with.
-	explicit RpcClientUSubscription(
-	    std::shared_ptr<transport::UTransport> transport);
+	explicit RpcClientUSubscription::RpcClientUSubscription(
+		std::shared_ptr<transport::UTransport> transport)
+		: transport_(std::move(transport)), uuri_builder_(USubscriptionUUriBuilder()) {}
+
 
 	/// @brief Destructor
 	~RpcClientUSubscription() override = default;

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -20,6 +20,7 @@
 #include <up-cpp/transport/UTransport.h>
 
 #include "up-cpp/client/usubscription/v3/USubscription.h"
+#include "up-cpp/client/usubscription/v3/USubscriptionUUriBuilder.h"
 
 namespace uprotocol::core::usubscription::v3 {
 using v3::SubscriptionRequest;
@@ -48,64 +49,6 @@ struct RpcClientUSubscriptionOptions {
 	std::optional<google::protobuf::Any> subscription_details;
 };
 
-/// @struct uSubscriptionUUriBuilder
-/// @brief Structure to build uSubscription request URIs.
-///
-/// This structure is used to build URIs for uSubscription service. It uses the
-/// service options from uSubscription proto to set the authority name, ue_id,
-/// ue_version_major, and the notification topic resource ID in the URI.
-struct USubscriptionUUriBuilder {
-private:
-	/// URI for the uSubscription service
-	v1::UUri uri_;
-	/// Resource ID of the notification topic
-	uint32_t sink_resource_id_;
-
-public:
-	/// @brief Constructor for USubscriptionUUriBuilder.
-	USubscriptionUUriBuilder() {
-		// Get the service descriptor
-		const google::protobuf::ServiceDescriptor* service =
-		    uSubscription::descriptor();
-		const auto& service_options = service->options();
-
-		// Get the service options
-		const auto& service_name =
-		    service_options.GetExtension(uprotocol::service_name);
-		const auto& service_version_major =
-		    service_options.GetExtension(uprotocol::service_version_major);
-		const auto& service_id =
-		    service_options.GetExtension(uprotocol::service_id);
-		const auto& notification_topic =
-		    service_options.GetExtension(uprotocol::notification_topic, 0);
-
-		// Set the values in the URI
-		uri_.set_authority_name(service_name);
-		uri_.set_ue_id(service_id);
-		uri_.set_ue_version_major(service_version_major);
-		sink_resource_id_ = notification_topic.id();
-	}
-
-	/// @brief Get the URI with a specific resource ID.
-	///
-	/// @param resource_id The resource ID to set in the URI.
-	///
-	/// @return The URI with the specified resource ID.
-	v1::UUri getServiceUriWithResourceId(uint32_t resource_id) const {
-		v1::UUri uri = uri_;  // Copy the base URI
-		uri.set_resource_id(resource_id);
-		return uri;
-	}
-
-	/// @brief Get the notification URI.
-	///
-	/// @return The notification URI.
-	v1::UUri getNotificationUri() const {
-		v1::UUri uri = uri_;  // Copy the base URI
-		uri.set_resource_id(sink_resource_id_);
-		return uri;
-	}
-};
 
 /// @brief Interface for uEntities to create subscriptions.
 ///
@@ -136,52 +79,6 @@ struct RpcClientUSubscription : USubscription {
 	///
 	utils::Expected<SubscriptionResponse, v1::UStatus> subscribe(
 	    const SubscriptionRequest& subscription_request) override;
-	// void subscribe(google::protobuf::RpcController* controller,
-	// 	const ::uprotocol::core::usubscription::v3::SubscriptionRequest*
-	// request,
-	// 	::uprotocol::core::usubscription::v3::SubscriptionResponse* response,
-	// 	::google::protobuf::Closure* done) override;
-
-	/// @brief Unsubscribe from the topic and call uSubscription service to
-	/// close the subscription.
-	// void Unsubscribe(google::protobuf::RpcController* controller,
-	// 	const ::uprotocol::core::usubscription::v3::UnsubscribeRequest* request,
-	// 	::uprotocol::core::usubscription::v3::UnsubscribeResponse* response,
-	// 	::google::protobuf::Closure* done) override;
-
-	// /// @brief Fetch all subscriptions for a given topic or subscriber
-	// contained inside a [`FetchSubscriptionsRequest`] void
-	// FetchSubscriptions(google::protobuf::RpcController* controller, 	const
-	// ::uprotocol::core::usubscription::v3::FetchSubscriptionsRequest* request,
-	// 	::uprotocol::core::usubscription::v3::FetchSubscriptionsResponse*
-	// response,
-	// 	::google::protobuf::Closure* done) override;
-
-	// /// @brief Register for notifications relevant to a given topic inside a
-	// [`NotificationsRequest`]
-	// /// changing in subscription status.
-	// void RegisterForNotifications(google::protobuf::RpcController*
-	// controller, 	const
-	// ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
-	// 	::uprotocol::core::usubscription::v3::NotificationsResponse* response,
-	// 	::google::protobuf::Closure* done) override;
-
-	// /// @brief Unregister for notifications relevant to a given topic inside
-	// a [`NotificationsRequest`]
-	// /// changing in subscription status.
-	// void UnregisterForNotifications(google::protobuf::RpcController*
-	// controller, 	const
-	// ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
-	// 	::uprotocol::core::usubscription::v3::NotificationsResponse* response,
-	// 	::google::protobuf::Closure* done) override;
-
-	// /// @brief Fetch a list of subscribers that are currently subscribed to a
-	// given topic in a [`FetchSubscribersRequest`] void
-	// FetchSubscribers(google::protobuf::RpcController* controller, 	const
-	// ::uprotocol::core::usubscription::v3::FetchSubscribersRequest* request,
-	// 	::uprotocol::core::usubscription::v3::FetchSubscribersResponse*
-	// response,
-	// 	::google::protobuf::Closure* done) override;
 
 	/// @brief Destructor
 	~RpcClientUSubscription() override = default;
@@ -201,9 +98,6 @@ private:
 	// Transport
 	std::shared_ptr<transport::UTransport> transport_;
 
-	// Topic to subscribe to
-	const v1::UUri subscription_topic_;
-
 	// Additional details about uSubscription service
 	RpcClientUSubscriptionOptions rpc_client_usubscription_options_;
 
@@ -218,9 +112,8 @@ private:
 	//     std::shared_ptr<uprotocol::transport::UTransport>&&, const v1::UUri&&,
 	//     RpcClientUSubscriptionOptions&&);
 
-public:
 	/// @brief Build SubscriptionRequest for subscription request
-	SubscriptionRequest buildSubscriptionRequest();
+	SubscriptionRequest buildSubscriptionRequest(const v1::UUri& subscription_topic);
 	//
 	// /// @brief  Build UnsubscriptionRequest for unsubscription request
 	// UnsubscribeRequest buildUnsubscriptionRequest();

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -70,7 +70,7 @@ public:
 		const auto& service_options = service->options();
 
 		// Get the service options
-		const auto& service_name = "test.name";
+		const auto& service_name = "usubscription.local";
 		    // service_options.GetExtension(uprotocol::service_name);
 		const auto& service_version_major =
 		    service_options.GetExtension(uprotocol::service_version_major);

--- a/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
+++ b/include/up-cpp/client/usubscription/v3/RpcClientUSubscription.h
@@ -218,6 +218,7 @@ private:
 	//     std::shared_ptr<uprotocol::transport::UTransport>&&, const v1::UUri&&,
 	//     RpcClientUSubscriptionOptions&&);
 
+public:
 	/// @brief Build SubscriptionRequest for subscription request
 	SubscriptionRequest buildSubscriptionRequest();
 	//

--- a/include/up-cpp/client/usubscription/v3/USubscription.h
+++ b/include/up-cpp/client/usubscription/v3/USubscription.h
@@ -3,31 +3,36 @@
 #include <uprotocol/core/usubscription/v3/usubscription.pb.h>
 #include <uprotocol/v1/umessage.pb.h>
 #include <uprotocol/v1/ustatus.pb.h>
+
 #include "up-cpp/utils/Expected.h"
 
 namespace uprotocol::core::usubscription::v3 {
 
-	struct USubscription {
+struct USubscription {
+	template <typename R>
+	using ResponseOrStatus = utils::Expected<R, v1::UStatus>;
 
-		template<typename R>
-		using ResponseOrStatus = utils::Expected<R, v1::UStatus>;
+	virtual ~USubscription() = default;
 
-		virtual ~USubscription() = default;
+	virtual ResponseOrStatus<SubscriptionResponse> subscribe(
+	    const SubscriptionRequest& subscription_request) = 0;
 
-		virtual ResponseOrStatus<SubscriptionResponse> subscribe(const SubscriptionRequest& subscription_request) = 0;
+	// virtual UnsubscribeResponse unsubscribe(const UnsubscribeRequest&
+	// unsubscribe_request) = 0;
 
-		// virtual UnsubscribeResponse unsubscribe(const UnsubscribeRequest& unsubscribe_request) = 0;
+	// virtual FetchSubscriptionsResponse fetch_subscriptions(const
+	// FetchSubscriptionsRequest& fetch_subscribers_request) = 0;
 
-		// virtual FetchSubscriptionsResponse fetch_subscriptions(const FetchSubscriptionsRequest& fetch_subscribers_request) = 0;
+	// virtual NotificationsResponse register_for_notifications(const
+	// NotificationsRequest& register_notifications_request) =0 ;
 
-		// virtual NotificationsResponse register_for_notifications(const NotificationsRequest& register_notifications_request) =0 ;
+	// virtual NotificationsResponse unregister_for_notifications(const
+	// NotificationsRequest& unregister_notifications_request) = 0;
 
-		// virtual NotificationsResponse unregister_for_notifications(const NotificationsRequest& unregister_notifications_request) = 0;
+	// virtual FetchSubscribersResponse fetch_subscribers(const
+	// FetchSubscribersRequest& fetch_subscribers_request) = 0;
+};
 
-		// virtual FetchSubscribersResponse fetch_subscribers(const FetchSubscribersRequest& fetch_subscribers_request) = 0;
+}  // namespace uprotocol::core::usubscription::v3
 
-	};
-
-} // namespace uprotocol::core::usubscription::v3
-
-#endif //USUBSCRIPTION_H
+#endif  // USUBSCRIPTION_H

--- a/include/up-cpp/client/usubscription/v3/USubscription.h
+++ b/include/up-cpp/client/usubscription/v3/USubscription.h
@@ -1,24 +1,30 @@
 #ifndef USUBSCRIPTION_H
 #define USUBSCRIPTION_H
 #include <uprotocol/core/usubscription/v3/usubscription.pb.h>
+#include <uprotocol/v1/umessage.pb.h>
+#include <uprotocol/v1/ustatus.pb.h>
+#include "up-cpp/utils/Expected.h"
 
 namespace uprotocol::core::usubscription::v3 {
 
 	struct USubscription {
 
+		template<typename R>
+		using ResponseOrStatus = utils::Expected<R, v1::UStatus>;
+
 		virtual ~USubscription() = default;
 
-		virtual SubscriptionResponse subscribe(const SubscriptionRequest& subscription_request) = 0;
+		virtual ResponseOrStatus<SubscriptionResponse> subscribe(const SubscriptionRequest& subscription_request) = 0;
 
-		virtual UnsubscribeResponse unsubscribe(const UnsubscribeRequest& unsubscribe_request) = 0;
+		// virtual UnsubscribeResponse unsubscribe(const UnsubscribeRequest& unsubscribe_request) = 0;
 
-		virtual FetchSubscriptionsResponse fetch_subscriptions(const FetchSubscriptionsRequest& fetch_subscribers_request) = 0;
+		// virtual FetchSubscriptionsResponse fetch_subscriptions(const FetchSubscriptionsRequest& fetch_subscribers_request) = 0;
 
-		virtual NotificationsResponse register_for_notifications(const NotificationsRequest& register_notifications_request) =0 ;
+		// virtual NotificationsResponse register_for_notifications(const NotificationsRequest& register_notifications_request) =0 ;
 
-		virtual NotificationsResponse unregister_for_notifications(const NotificationsRequest& unregister_notifications_request) = 0;
+		// virtual NotificationsResponse unregister_for_notifications(const NotificationsRequest& unregister_notifications_request) = 0;
 
-		virtual FetchSubscribersResponse fetch_subscribers(const FetchSubscribersRequest& fetch_subscribers_request) = 0;
+		// virtual FetchSubscribersResponse fetch_subscribers(const FetchSubscribersRequest& fetch_subscribers_request) = 0;
 
 	};
 

--- a/include/up-cpp/client/usubscription/v3/USubscription.h
+++ b/include/up-cpp/client/usubscription/v3/USubscription.h
@@ -1,0 +1,31 @@
+//
+// Created by max on 28.04.25.
+//
+
+#ifndef USUBSCRIPTION_H
+#define USUBSCRIPTION_H
+#include "RpcClientUSubscription.h"
+
+namespace uprotocol::core::usubscription::v3 {
+
+	struct USubscription {
+
+		virtual ~USubscription() = default;
+
+		virtual SubscriptionResponse subscribe(const SubscriptionRequest& subscription_request) = 0;
+
+		virtual UnsubscribeResponse unsubscribe(const UnsubscribeRequest& unsubscribe_request) = 0;
+
+		virtual FetchSubscriptionsResponse fetch_subscriptions(const FetchSubscriptionsRequest& fetch_subscribers_request) = 0;
+
+		virtual NotificationsResponse register_for_notifications(const NotificationsRequest& register_notifications_request) =0 ;
+
+		virtual NotificationsResponse unregister_for_notifications(const NotificationsRequest& unregister_notifications_request) = 0;
+
+		virtual FetchSubscribersResponse fetch_subscribers(const FetchSubscribersRequest& fetch_subscribers_request) = 0;
+
+	};
+
+} // namespace uprotocol::core::usubscription::v3
+
+#endif //USUBSCRIPTION_H

--- a/include/up-cpp/client/usubscription/v3/USubscription.h
+++ b/include/up-cpp/client/usubscription/v3/USubscription.h
@@ -1,10 +1,6 @@
-//
-// Created by max on 28.04.25.
-//
-
 #ifndef USUBSCRIPTION_H
 #define USUBSCRIPTION_H
-#include "RpcClientUSubscription.h"
+#include <uprotocol/core/usubscription/v3/usubscription.pb.h>
 
 namespace uprotocol::core::usubscription::v3 {
 

--- a/include/up-cpp/client/usubscription/v3/USubscriptionUUriBuilder.h
+++ b/include/up-cpp/client/usubscription/v3/USubscriptionUUriBuilder.h
@@ -1,0 +1,49 @@
+//
+// Created by max on 10.05.25.
+//
+
+#ifndef USUBSCRIPTIONUURIBUILDER_H
+#define USUBSCRIPTIONUURIBUILDER_H
+
+#include <uprotocol/uoptions.pb.h>
+#include <uprotocol/core/usubscription/v3/usubscription.pb.h>
+
+#include "up-cpp/datamodel/validator/UUri.h"
+
+namespace uprotocol::core::usubscription::v3 {
+/// @struct USubscriptionUUriBuilder
+/// @brief Structure to build uSubscription request URIs.
+///
+/// This structure is used to build URIs for uSubscription service. It uses the
+/// service options from uSubscription proto to set the authority name, ue_id,
+/// ue_version_major, and the notification topic resource ID in the URI.
+struct USubscriptionUUriBuilder {
+
+	/// @brief Constructor for USubscriptionUUriBuilder.
+	explicit USubscriptionUUriBuilder();
+
+	/// @brief Get the URI with a specific resource ID.
+	///
+	/// @param resource_id The resource ID to set in the URI.
+	///
+	/// @return The URI with the specified resource ID.
+	v1::UUri getServiceUriWithResourceId(uint32_t resource_id) const;
+
+	/// @brief Get the notification URI.
+	///
+	/// @return The notification URI.
+	v1::UUri getNotificationUri() const {
+		v1::UUri uri = base_uri_;  // Copy the base URI
+		uri.set_resource_id(sink_resource_id_);
+		return uri;
+	}
+
+	private:
+		/// URI for the uSubscription service
+		v1::UUri base_uri_;
+		/// Resource ID of the notification topic
+		uint32_t sink_resource_id_;
+	};
+} // namespace uprotocol::core::usubscription::v3
+
+#endif //USUBSCRIPTIONUURIBUILDER_H

--- a/include/up-cpp/client/usubscription/v3/USubscriptionUUriBuilder.h
+++ b/include/up-cpp/client/usubscription/v3/USubscriptionUUriBuilder.h
@@ -1,7 +1,3 @@
-//
-// Created by max on 10.05.25.
-//
-
 #ifndef USUBSCRIPTIONUURIBUILDER_H
 #define USUBSCRIPTIONUURIBUILDER_H
 

--- a/include/up-cpp/client/usubscription/v3/USubscriptionUUriBuilder.h
+++ b/include/up-cpp/client/usubscription/v3/USubscriptionUUriBuilder.h
@@ -25,20 +25,9 @@ struct USubscriptionUUriBuilder {
 	/// @return The URI with the specified resource ID.
 	v1::UUri getServiceUriWithResourceId(uint32_t resource_id) const;
 
-	/// @brief Get the notification URI.
-	///
-	/// @return The notification URI.
-	v1::UUri getNotificationUri() const {
-		v1::UUri uri = base_uri_;  // Copy the base URI
-		uri.set_resource_id(sink_resource_id_);
-		return uri;
-	}
-
 	private:
 		/// URI for the uSubscription service
 		v1::UUri base_uri_;
-		/// Resource ID of the notification topic
-		uint32_t sink_resource_id_;
 	};
 } // namespace uprotocol::core::usubscription::v3
 

--- a/include/up-cpp/utils/ProtoConverter.h
+++ b/include/up-cpp/utils/ProtoConverter.h
@@ -52,7 +52,7 @@ struct ProtoConverter {
 	/// @param subscription_topic the UUri of the topic to unsubscribe from
 	/// @return the built UnsubscribeRequest
 	static UnsubscribeRequest BuildUnSubscribeRequest(
-	    const v1::UUri& subscription_topic);
+	    const v1::UUri& subscription_topic);UnsubscribeRequest BuildUnSubscribeRequest(const v1::UUri& uri, const SubscribeAttributes& attributes);
 };
 };      // namespace uprotocol::utils
 #endif  // UP_CPP_UTILS_PROTOCONVERTER_H

--- a/src/client/usubscription/v3/RequestBuilder.cpp
+++ b/src/client/usubscription/v3/RequestBuilder.cpp
@@ -1,4 +1,5 @@
 #include <uprotocol/core/usubscription/v3/usubscription.pb.h>
+#include <iostream>
 #include "up-cpp/client/usubscription/v3/RequestBuilder.h"
 
 namespace uprotocol::core::usubscription::v3 {
@@ -10,6 +11,11 @@ SubscriptionRequest RequestBuilder::buildSubscriptionRequest(
 		options_.when_expire,
 		options_.subscription_details,
 		options_.sample_period_ms);
+	if (options_.permission_level.has_value()) {
+		std::cout << "PERMISSION LEVEL:" << options_.permission_level.value()<<std::endl;
+	} else {
+		std::cout << "no when_expire" << std::endl;
+	}
 
 	return utils::ProtoConverter::BuildSubscriptionRequest(
 		topic, attributes);

--- a/src/client/usubscription/v3/RequestBuilder.cpp
+++ b/src/client/usubscription/v3/RequestBuilder.cpp
@@ -1,0 +1,30 @@
+#include <uprotocol/core/usubscription/v3/usubscription.pb.h>
+#include "up-cpp/client/usubscription/v3/RequestBuilder.h"
+
+namespace uprotocol::core::usubscription::v3 {
+
+
+SubscriptionRequest RequestBuilder::buildSubscriptionRequest(
+	const v1::UUri& topic) const {
+	auto attributes = utils::ProtoConverter::BuildSubscribeAttributes(
+		options_.when_expire,
+		options_.subscription_details,
+		options_.sample_period_ms);
+
+	return utils::ProtoConverter::BuildSubscriptionRequest(
+		topic, attributes);
+}
+
+UnsubscribeRequest RequestBuilder::buildUnsubscribeRequest(
+    const v1::UUri& topic) {
+	// auto attributes = utils::ProtoConverter::BuildSubscribeAttributes(
+	// 	options_.when_expire,
+	// 	options_.subscription_details,
+	// 	options_.sample_period_ms);
+
+	return utils::ProtoConverter::BuildUnSubscribeRequest(
+		topic);
+}
+
+
+} // namespace uprotocol::core::usubscription::v3

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -30,24 +30,11 @@ auto priority = uprotocol::v1::UPriority::UPRIORITY_CS4;  // MUST be >= 4
 namespace uprotocol::core::usubscription::v3 {
 
 RpcClientUSubscription::RpcClientUSubscription(
-    std::shared_ptr<transport::UTransport> transport,
-    RpcClientUSubscriptionOptions rpc_client_usubscription_options)
-    : transport_(std::move(transport)),
-      rpc_client_usubscription_options_(
-          std::move(rpc_client_usubscription_options)) {
+    std::shared_ptr<transport::UTransport> transport)
+    : transport_(std::move(transport)) {
 	uuri_builder_ = USubscriptionUUriBuilder();
 }
 
-SubscriptionRequest RpcClientUSubscription::buildSubscriptionRequest(const v1::UUri& subscription_topic) {
-	auto attributes = utils::ProtoConverter::BuildSubscribeAttributes(
-	    rpc_client_usubscription_options_.when_expire,
-	    rpc_client_usubscription_options_.subscription_details,
-	    rpc_client_usubscription_options_.sample_period_ms);
-
-	auto subscription_request = utils::ProtoConverter::BuildSubscriptionRequest(
-	    subscription_topic, attributes);
-	return subscription_request;
-}
 
 RpcClientUSubscription::ResponseOrStatus<SubscriptionResponse>
 RpcClientUSubscription::subscribe(

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -10,6 +10,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <up-cpp/client/usubscription/v3/RpcClientUSubscription.h>
+#include <up-cpp/client/usubscription/v3/USubscription.h>
 #include <uprotocol/core/usubscription/v3/usubscription.pb.h>
 
 #include <utility>
@@ -100,11 +101,12 @@ void RpcClientUSubscription::Subscribe(
 	::google::protobuf::Closure* done) {
 	
 	constexpr uint16_t RESOURCE_ID_SUBSCRIBE = 0x0001;
+	// TODO(lennart) see default_call_options() for the request in Rust
 	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
 	auto subscription_request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
 	auto priority = uprotocol::v1::UPriority::UPRIORITY_CS4; // TODO(lennart) priority
 
-	auto options = uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions();
+	auto options = uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions(); // Might serve as default_call_options() in Rust
 
 
 	rpc_client_ = std::make_unique<communication::RpcClient>(

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -29,12 +29,6 @@ auto priority = uprotocol::v1::UPriority::UPRIORITY_CS4;  // MUST be >= 4
 
 namespace uprotocol::core::usubscription::v3 {
 
-RpcClientUSubscription::RpcClientUSubscription(
-    std::shared_ptr<transport::UTransport> transport)
-    : transport_(std::move(transport)) {
-	uuri_builder_ = USubscriptionUUriBuilder();
-}
-
 
 RpcClientUSubscription::ResponseOrStatus<SubscriptionResponse>
 RpcClientUSubscription::subscribe(

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -15,79 +15,31 @@
 #include <uprotocol/v1/ustatus.pb.h>
 
 #include <utility>
+
 #include "up-cpp/communication/RpcClient.h"
+#include "up-cpp/transport/UTransport.h"
 
 constexpr uint16_t RESOURCE_ID_SUBSCRIBE = 0x0001;
 // TODO(lennart) see default_call_options() for the request in Rust
-constexpr auto SUBSCRIPTION_REQUEST_TTL = std::chrono::milliseconds(0x0800); // TODO(lennart) change time
-auto priority = uprotocol::v1::UPriority::UPRIORITY_CS4;	// MUST be >= 4
+constexpr auto SUBSCRIPTION_REQUEST_TTL =
+    std::chrono::milliseconds(0x0800);  // TODO(lennart) change time
+auto priority = uprotocol::v1::UPriority::UPRIORITY_CS4;  // MUST be >= 4
 
 namespace uprotocol::core::usubscription::v3 {
 
-RpcClientUSubscription::RpcClientUSubscription(std::shared_ptr<uprotocol::transport::UTransport> transport,
-                   RpcClientUSubscriptionOptions rpc_client_usubscription_options)
+RpcClientUSubscription::RpcClientUSubscription(
+    std::shared_ptr<transport::UTransport> transport,
+    RpcClientUSubscriptionOptions rpc_client_usubscription_options)
     : transport_(std::move(transport)),
-      rpc_client_usubscription_options_(std::move(rpc_client_usubscription_options)) {
-	// Initialize uSubscriptionUUriBuilder_
-	uSubscriptionUUriBuilder_ = USubscriptionUUriBuilder();
+      rpc_client_usubscription_options_(
+          std::move(rpc_client_usubscription_options)) {
+	uuri_builder_ = USubscriptionUUriBuilder();
 }
-
-// [[nodiscard]] RpcClientUSubscription::RpcClientUSubscriptionOrStatus RpcClientUSubscription::create(
-//     std::shared_ptr<transport::UTransport> transport,
-//     const v1::UUri& subscription_topic, ListenCallback&& callback,
-//     RpcClientUSubscriptionOptions rpc_client_usubscription_options) {
-// 	auto rpc_client_usubscription = std::make_unique<RpcClientUSubscription>(
-// 	    std::forward<std::shared_ptr<transport::UTransport>>(transport),
-// 	    std::forward<RpcClientUSubscriptionOptions>(rpc_client_usubscription_options));
-	
-// 	google::protobuf::RpcController *controller = nullptr;
-// 	::uprotocol::core::usubscription::v3::SubscriptionRequest const *subscription_request = nullptr;
-// 	SubscriptionResponse *subscription_response = nullptr;
-
-// 	// Attempt to connect create notification sink for updates.
-// 	auto status = rpc_client_usubscription->createNotificationSink();
-// 	if (status.code() == v1::UCode::OK) {
-// 		rpc_client_usubscription->Subscribe(controller, subscription_request,
-// 			subscription_response, nullptr);
-// 		if (controller == nullptr) {
-// 			return RpcClientUSubscriptionOrStatus(std::move(rpc_client_usubscription));
-// 		}
-// 		return RpcClientUSubscriptionOrStatus(utils::Unexpected<v1::UStatus>(status));
-// 	}
-// 	// If connection fails, return the error status.
-// 	return RpcClientUSubscriptionOrStatus(utils::Unexpected<v1::UStatus>(status));
-// }
-
-// v1::UStatus RpcClientUSubscription::createNotificationSink() {
-// 	auto notification_sink_callback = [this](const v1::UMessage& update) {
-// 		if (update.has_payload()) {
-// 			Update data;
-// 			if (data.ParseFromString(update.payload())) {
-// 				if (data.topic().SerializeAsString() ==
-// 				    subscription_topic_.SerializeAsString()) {
-// 					subscription_update_ = std::move(data);
-// 				}
-// 			}
-// 		}
-// 	};
-
-// 	auto notification_topic = uSubscriptionUUriBuilder_.getNotificationUri();
-
-// 	auto result = communication::NotificationSink::create(
-// 	    transport_, std::move(notification_sink_callback), notification_topic);
-
-// 	if (result.has_value()) {
-// 		noficationSinkHandle_ = std::move(result).value();
-// 		v1::UStatus status;
-// 		status.set_code(v1::UCode::OK);
-// 		return status;
-// 	}
-// 	return result.error();
-// }
 
 SubscriptionRequest RpcClientUSubscription::buildSubscriptionRequest() {
 	auto attributes = utils::ProtoConverter::BuildSubscribeAttributes(
-	    rpc_client_usubscription_options_.when_expire, rpc_client_usubscription_options_.subscription_details,
+	    rpc_client_usubscription_options_.when_expire,
+	    rpc_client_usubscription_options_.subscription_details,
 	    rpc_client_usubscription_options_.sample_period_ms);
 
 	auto subscription_request = utils::ProtoConverter::BuildSubscriptionRequest(
@@ -95,19 +47,21 @@ SubscriptionRequest RpcClientUSubscription::buildSubscriptionRequest() {
 	return subscription_request;
 }
 
-RpcClientUSubscription::ResponseOrStatus<SubscriptionResponse> RpcClientUSubscription::subscribe(const SubscriptionRequest& subscription_request) {
-
+RpcClientUSubscription::ResponseOrStatus<SubscriptionResponse>
+RpcClientUSubscription::subscribe(
+    const SubscriptionRequest& subscription_request) {
 	communication::RpcClient rpc_client(
-	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_SUBSCRIBE),
+	    transport_,
+	    uuri_builder_.getServiceUriWithResourceId(
+	        RESOURCE_ID_SUBSCRIBE),
 	    priority, SUBSCRIPTION_REQUEST_TTL);
 
 	datamodel::builder::Payload payload(subscription_request);
 
-	auto invoke_future =
-	    rpc_client.invokeMethod(std::move(payload));
+	auto invoke_future = rpc_client.invokeMethod(std::move(payload));
 
 	auto message_or_status = invoke_future.get();
-	
+
 	if (!message_or_status.has_value()) {
 		return ResponseOrStatus<SubscriptionResponse>(
 		    utils::Unexpected<v1::UStatus>(message_or_status.error()));
@@ -117,213 +71,12 @@ RpcClientUSubscription::ResponseOrStatus<SubscriptionResponse> RpcClientUSubscri
 	subscription_response.ParseFromString(message_or_status.value().payload());
 
 	if (subscription_response.topic().SerializeAsString() ==
-		subscription_topic_.SerializeAsString()) {
+	    subscription_topic_.SerializeAsString()) {
 		return ResponseOrStatus<SubscriptionResponse>(subscription_response);
 	}
 
 	return ResponseOrStatus<SubscriptionResponse>(
-		utils::Unexpected<v1::UStatus>(message_or_status.error()));
-		
+	    utils::Unexpected<v1::UStatus>(message_or_status.error()));
 }
-
-
-
-
-// UnsubscribeRequest RpcClientUSubscription::buildUnsubscriptionRequest() {
-// 	auto unsubscribe_request =
-// 	    utils::ProtoConverter::BuildUnSubscribeRequest(subscription_topic_);
-// 	return unsubscribe_request;
-// }
-
-// void RpcClientUSubscription::Unsubscribe(
-// 	google::protobuf::RpcController* controller,
-// 	const ::uprotocol::core::usubscription::v3::UnsubscribeRequest* request,
-// 	::uprotocol::core::usubscription::v3::UnsubscribeResponse* response,
-// 	::google::protobuf::Closure* done) {
-	
-// 	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
-// 	constexpr uint16_t RESOURCE_ID_UNSUBSCRIBE = 0x0002;
-// 	auto request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
-// 	auto priority = uprotocol::v1::UPriority::UPRIORITY_UNSPECIFIED;
-	
-// 	rpc_client_ = std::make_unique<communication::RpcClient>(
-// 	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_UNSUBSCRIBE),
-// 	    priority, request_ttl);
-
-// 	auto on_response = [this, response](const auto& maybe_response) {
-// 		if (maybe_response.has_value() &&
-// 		    maybe_response.value().has_payload()) {
-// 			if (response->ParseFromString(maybe_response.value().payload())) {
-// 				if (response->SerializeAsString() == // TODO(lennart) topic specific? See subscribe
-// 				    subscription_topic_.SerializeAsString()) { 
-// 					unsubscribe_response_ = *response;
-// 				}
-// 			}
-// 		}
-// 	};
-
-// 	// UnsubscribeRequest const unsubscribe_request = buildUnsubscriptionRequest();
-// 	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct
-// 	rpc_handle_ =
-// 	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
-
-// 	// TODO(lennart) any handle for the response?
-
-// 	subscriber_.reset();
-
-// 	done->Run();	
-// }
-
-// void RpcClientUSubscription::FetchSubscriptions(
-// 	google::protobuf::RpcController* controller,
-// 	const ::uprotocol::core::usubscription::v3::FetchSubscriptionsRequest* request,
-// 	::uprotocol::core::usubscription::v3::FetchSubscriptionsResponse* response,
-// 	::google::protobuf::Closure* done) {
-	
-// 	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
-// 	constexpr uint16_t RESOURCE_ID_FETCH_SUBSCRIPTIONS = 0x0003;
-// 	auto request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
-// 	auto priority = uprotocol::v1::UPriority::UPRIORITY_UNSPECIFIED;
-	
-// 	rpc_client_ = std::make_unique<communication::RpcClient>(
-// 	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_FETCH_SUBSCRIPTIONS),
-// 	    priority, request_ttl);
-
-// 	auto on_response = [this, response](const auto& maybe_response) {
-// 		if (maybe_response.has_value() &&
-// 		    maybe_response.value().has_payload()) {
-// 			if (response->ParseFromString(maybe_response.value().payload())) {
-// 				if (response->SerializeAsString() == // TODO(lennart) topic specific? See subscribe
-// 				    subscription_topic_.SerializeAsString()) { 
-// 					fetch_subscription_response_ = *response;
-// 				}
-// 			}
-// 		}
-// 	};
-
-// 	// FetchSubscriptionsRequest const fetch_subscriptions_request = buildFetchSubscriptionsRequest();
-// 	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct
-
-// 	rpc_handle_ =
-// 	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
-
-// 	// TODO(lennart) any handle for the response?
-
-// 	done->Run();	
-// }
-
-// void RpcClientUSubscription::RegisterForNotifications(
-// 	google::protobuf::RpcController* controller,
-// 	const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
-// 	::uprotocol::core::usubscription::v3::NotificationsResponse* response,
-// 	::google::protobuf::Closure* done) {
-	
-// 	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
-// 	constexpr uint16_t RESOURCE_ID_REGISTER_FOR_NOTIFICATIONS = 0x0006;
-// 	auto request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
-// 	auto priority = uprotocol::v1::UPriority::UPRIORITY_UNSPECIFIED;
-	
-// 	rpc_client_ = std::make_unique<communication::RpcClient>(
-// 	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_REGISTER_FOR_NOTIFICATIONS),
-// 	    priority, request_ttl);
-
-// 	auto on_response = [this, response](const auto& maybe_response) {
-// 		if (maybe_response.has_value() &&
-// 		    maybe_response.value().has_payload()) {
-// 			if (response->ParseFromString(maybe_response.value().payload())) {
-// 				if (response->SerializeAsString() == // TODO(lennart) topic specific? See subscribe
-// 				    subscription_topic_.SerializeAsString()) { 
-// 						notification_response_ = *response;
-// 				}
-// 			}
-// 		}
-// 	};
-
-// 	// NotificationsRequest const register_notifications_request = buildRegisterNotificationsRequest();
-// 	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct
-
-// 	rpc_handle_ =
-// 	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
-
-// 	// TODO(lennart) any handle for the response?
-
-// 	done->Run();	
-// }
-
-// void RpcClientUSubscription::UnregisterForNotifications(
-// 	google::protobuf::RpcController* controller,
-// 	const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
-// 	::uprotocol::core::usubscription::v3::NotificationsResponse* response,
-// 	::google::protobuf::Closure* done) {
-	
-// 	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
-// 	constexpr uint16_t RESOURCE_ID_UNREGISTER_FOR_NOTIFICATIONS = 0x0007;
-// 	auto request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
-// 	auto priority = uprotocol::v1::UPriority::UPRIORITY_UNSPECIFIED;
-	
-// 	rpc_client_ = std::make_unique<communication::RpcClient>(
-// 	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_UNREGISTER_FOR_NOTIFICATIONS),
-// 	    priority, request_ttl);
-
-// 	auto on_response = [this, response](const auto& maybe_response) {
-// 		if (maybe_response.has_value() &&
-// 		    maybe_response.value().has_payload()) {
-// 			if (response->ParseFromString(maybe_response.value().payload())) {
-// 				if (response->SerializeAsString() == // TODO(lennart) topic specific? See subscribe
-// 				    subscription_topic_.SerializeAsString()) { 
-// 						notification_response_ = *response;
-// 				}
-// 			}
-// 		}
-// 	};
-
-// 	// NotificationsRequest const unregister_notifications_request = buildUnregisterNotificationsRequest();
-// 	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct
-
-// 	rpc_handle_ =
-// 	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
-
-// 	// TODO(lennart) any handle for the response?
-
-// 	done->Run();	
-// }
-
-// void RpcClientUSubscription::FetchSubscribers(
-// 	google::protobuf::RpcController* controller,
-// 	const ::uprotocol::core::usubscription::v3::FetchSubscribersRequest* request,
-// 	::uprotocol::core::usubscription::v3::FetchSubscribersResponse* response,
-// 	::google::protobuf::Closure* done) {
-	
-// 	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
-// 	constexpr uint16_t RESOURCE_ID_FETCH_SUBSCRIBERS = 0x0008;
-// 	auto request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
-// 	auto priority = uprotocol::v1::UPriority::UPRIORITY_UNSPECIFIED;
-	
-// 	rpc_client_ = std::make_unique<communication::RpcClient>(
-// 	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_FETCH_SUBSCRIBERS),
-// 	    priority, request_ttl);
-
-// 	auto on_response = [this, response](const auto& maybe_response) {
-// 		if (maybe_response.has_value() &&
-// 		    maybe_response.value().has_payload()) {
-// 			if (response->ParseFromString(maybe_response.value().payload())) {
-// 				if (response->SerializeAsString() == // TODO(lennart) topic specific? See subscribe
-// 				    subscription_topic_.SerializeAsString()) { 
-// 						fetch_subscribers_response_ = *response;
-// 				}
-// 			}
-// 		}
-// 	};
-
-// 	// FetchSubscribersRequest const fetch_subscribers_request = buildFetchSubscribersRequest();
-// 	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct
-
-// 	rpc_handle_ =
-// 	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
-
-// 	// TODO(lennart) any handle for the response?
-
-// 	done->Run();	
-// }
 
 }  // namespace uprotocol::core::usubscription::v3

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -1,0 +1,18 @@
+//
+// Created by max on 28.04.25.
+//
+
+#include "up-cpp/client/usubscription/v3/RpcClientUSubscription.h"
+
+namespace uprotocol::core::usubscription::v3 {
+	using Payload = datamodel::builder::Payload;
+
+	SubscriptionResponse RpcClientUSubscription::subscribe(
+    const SubscriptionRequest& subscription_request) {
+		Payload test_test(subscription_request);
+		auto invoke_handle = client_->invokeMethod(test_test, //TODO(max));
+	    return SubscriptionResponse();
+    }
+
+    } // namespace uprotocol::core::usubscription::v3
+

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -43,6 +43,9 @@ void RpcClientUSubscription::Subscribe(
 
 		rpc_handle_ = rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
 
+		auto result = communication::Subscriber::subscribe(
+			transport_, subscription_topic_, std::move(callback)); // TODO(lennart) callback? 
+
 		if (static_cast<int>(rpc_handle_.isConnected()) == v1::OK) {		// TODO(lennart): check if this is correct
 			response->CopyFrom(rpc_handle_.value);  // Copy data to the response
 		} else {

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -39,7 +39,7 @@ void RpcClientUSubscription::Subscribe(
 	};
 
 	try {
-		auto payload = datamodel::builder::Payload(request);
+		auto payload = datamodel::builder::Payload(*request);
 
 		rpc_handle_ = rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
 

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -12,75 +12,78 @@
 #include <up-cpp/client/usubscription/v3/RpcClientUSubscription.h>
 #include <up-cpp/client/usubscription/v3/USubscription.h>
 #include <uprotocol/core/usubscription/v3/usubscription.pb.h>
+#include <uprotocol/v1/ustatus.pb.h>
 
 #include <utility>
+#include "up-cpp/communication/RpcClient.h"
+
+constexpr uint16_t RESOURCE_ID_SUBSCRIBE = 0x0001;
+// TODO(lennart) see default_call_options() for the request in Rust
+constexpr auto SUBSCRIPTION_REQUEST_TTL = std::chrono::milliseconds(0x0800); // TODO(lennart) change time
+auto priority = uprotocol::v1::UPriority::UPRIORITY_CS4;	// MUST be >= 4
 
 namespace uprotocol::core::usubscription::v3 {
 
 RpcClientUSubscription::RpcClientUSubscription(std::shared_ptr<uprotocol::transport::UTransport> transport,
-                   v1::UUri subscription_topic,
                    RpcClientUSubscriptionOptions rpc_client_usubscription_options)
     : transport_(std::move(transport)),
-      subscription_topic_(std::move(subscription_topic)),
-      rpc_client_usubscription_options_(std::move(rpc_client_usubscription_options)),
-      rpc_client_(nullptr) {
+      rpc_client_usubscription_options_(std::move(rpc_client_usubscription_options)) {
 	// Initialize uSubscriptionUUriBuilder_
 	uSubscriptionUUriBuilder_ = USubscriptionUUriBuilder();
 }
 
-[[nodiscard]] RpcClientUSubscription::RpcClientUSubscriptionOrStatus RpcClientUSubscription::create(
-    std::shared_ptr<transport::UTransport> transport,
-    const v1::UUri& subscription_topic, ListenCallback&& callback,
-    RpcClientUSubscriptionOptions rpc_client_usubscription_options) {
-	auto rpc_client_usubscription = std::make_unique<RpcClientUSubscription>(
-	    std::forward<std::shared_ptr<transport::UTransport>>(transport),
-	    std::forward<const v1::UUri>(subscription_topic),
-	    std::forward<RpcClientUSubscriptionOptions>(rpc_client_usubscription_options));
+// [[nodiscard]] RpcClientUSubscription::RpcClientUSubscriptionOrStatus RpcClientUSubscription::create(
+//     std::shared_ptr<transport::UTransport> transport,
+//     const v1::UUri& subscription_topic, ListenCallback&& callback,
+//     RpcClientUSubscriptionOptions rpc_client_usubscription_options) {
+// 	auto rpc_client_usubscription = std::make_unique<RpcClientUSubscription>(
+// 	    std::forward<std::shared_ptr<transport::UTransport>>(transport),
+// 	    std::forward<RpcClientUSubscriptionOptions>(rpc_client_usubscription_options));
 	
-	google::protobuf::RpcController *controller = nullptr;
-	::uprotocol::core::usubscription::v3::SubscriptionRequest const *subscription_request = nullptr;
-	SubscriptionResponse *subscription_response = nullptr;
+// 	google::protobuf::RpcController *controller = nullptr;
+// 	::uprotocol::core::usubscription::v3::SubscriptionRequest const *subscription_request = nullptr;
+// 	SubscriptionResponse *subscription_response = nullptr;
 
-	// Attempt to connect create notification sink for updates.
-	auto status = rpc_client_usubscription->createNotificationSink();
-	if (status.code() == v1::UCode::OK) {
-		rpc_client_usubscription->Subscribe(controller, subscription_request,
-			subscription_response, nullptr);
-		if (controller == nullptr) {
-			return RpcClientUSubscriptionOrStatus(std::move(rpc_client_usubscription));
-		}
-		return RpcClientUSubscriptionOrStatus(utils::Unexpected<v1::UStatus>(status));
-	}
-	// If connection fails, return the error status.
-	return RpcClientUSubscriptionOrStatus(utils::Unexpected<v1::UStatus>(status));
-}
+// 	// Attempt to connect create notification sink for updates.
+// 	auto status = rpc_client_usubscription->createNotificationSink();
+// 	if (status.code() == v1::UCode::OK) {
+// 		rpc_client_usubscription->Subscribe(controller, subscription_request,
+// 			subscription_response, nullptr);
+// 		if (controller == nullptr) {
+// 			return RpcClientUSubscriptionOrStatus(std::move(rpc_client_usubscription));
+// 		}
+// 		return RpcClientUSubscriptionOrStatus(utils::Unexpected<v1::UStatus>(status));
+// 	}
+// 	// If connection fails, return the error status.
+// 	return RpcClientUSubscriptionOrStatus(utils::Unexpected<v1::UStatus>(status));
+// }
 
-v1::UStatus RpcClientUSubscription::createNotificationSink() {
-	auto notification_sink_callback = [this](const v1::UMessage& update) {
-		if (update.has_payload()) {
-			Update data;
-			if (data.ParseFromString(update.payload())) {
-				if (data.topic().SerializeAsString() ==
-				    subscription_topic_.SerializeAsString()) {
-					subscription_update_ = std::move(data);
-				}
-			}
-		}
-	};
+// v1::UStatus RpcClientUSubscription::createNotificationSink() {
+// 	auto notification_sink_callback = [this](const v1::UMessage& update) {
+// 		if (update.has_payload()) {
+// 			Update data;
+// 			if (data.ParseFromString(update.payload())) {
+// 				if (data.topic().SerializeAsString() ==
+// 				    subscription_topic_.SerializeAsString()) {
+// 					subscription_update_ = std::move(data);
+// 				}
+// 			}
+// 		}
+// 	};
 
-	auto notification_topic = uSubscriptionUUriBuilder_.getNotificationUri();
+// 	auto notification_topic = uSubscriptionUUriBuilder_.getNotificationUri();
 
-	auto result = communication::NotificationSink::create(
-	    transport_, std::move(notification_sink_callback), notification_topic);
+// 	auto result = communication::NotificationSink::create(
+// 	    transport_, std::move(notification_sink_callback), notification_topic);
 
-	if (result.has_value()) {
-		noficationSinkHandle_ = std::move(result).value();
-		v1::UStatus status;
-		status.set_code(v1::UCode::OK);
-		return status;
-	}
-	return result.error();
-}
+// 	if (result.has_value()) {
+// 		noficationSinkHandle_ = std::move(result).value();
+// 		v1::UStatus status;
+// 		status.set_code(v1::UCode::OK);
+// 		return status;
+// 	}
+// 	return result.error();
+// }
 
 SubscriptionRequest RpcClientUSubscription::buildSubscriptionRequest() {
 	auto attributes = utils::ProtoConverter::BuildSubscribeAttributes(
@@ -92,257 +95,235 @@ SubscriptionRequest RpcClientUSubscription::buildSubscriptionRequest() {
 	return subscription_request;
 }
 
-void RpcClientUSubscription::Subscribe(
-	google::protobuf::RpcController* controller,
-	const ::uprotocol::core::usubscription::v3::SubscriptionRequest* request,
-	::uprotocol::core::usubscription::v3::SubscriptionResponse* response,
-	::google::protobuf::Closure* done) {
-	
-	constexpr uint16_t RESOURCE_ID_SUBSCRIBE = 0x0001;
-	// TODO(lennart) see default_call_options() for the request in Rust
-	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
-	auto subscription_request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
-	auto priority = uprotocol::v1::UPriority::UPRIORITY_UNSPECIFIED;
+RpcClientUSubscription::ResponseOrStatus<SubscriptionResponse> RpcClientUSubscription::subscribe(const SubscriptionRequest& subscription_request) {
 
-
-	rpc_client_ = std::make_unique<communication::RpcClient>(
+	communication::RpcClient rpc_client(
 	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_SUBSCRIBE),
-	    priority, subscription_request_ttl);
+	    priority, SUBSCRIPTION_REQUEST_TTL);
 
-	auto on_response = [this, response](const auto& maybe_response) {
-		if (maybe_response.has_value() &&
-		    maybe_response.value().has_payload()) {
-			if (response->ParseFromString(maybe_response.value().payload())) {
-				if (response->topic().SerializeAsString() ==
-				    subscription_topic_.SerializeAsString()) {
-					subscription_response_ = *response;
-				}
-			}
-		}
-	};
+	datamodel::builder::Payload payload(subscription_request);
 
-	// SubscriptionRequest const subscription_request = buildSubscriptionRequest();
-	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct, has been subscription_request before
+	auto invoke_future =
+	    rpc_client.invokeMethod(std::move(payload));
 
-	rpc_handle_ =
-	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));	
-
-	// TODO(lennart) any handle for the response?
-
-	// Question TODO(max): communication::Subscriber::subscribe(...) necessary? 
-	auto subscription_callback = nullptr; // TODO(lennart) update with correct callback
-	// Create a L2 subscription
-	auto result = communication::Subscriber::subscribe(
-	    transport_, subscription_topic_, std::move(subscription_callback));
-
-	if (result.has_value()) {
-		subscriber_ = std::move(result).value();
-		v1::UStatus status;
-		status.set_code(v1::UCode::OK);
-		// return status;
-		done->Run();
+	auto message_or_status = invoke_future.get();
+	
+	if (!message_or_status.has_value()) {
+		return ResponseOrStatus<SubscriptionResponse>(
+		    utils::Unexpected<v1::UStatus>(message_or_status.error()));
 	}
 
-	controller->SetFailed("result.error()"); // TODO(lennart) method needs to be implemented
-	
-	done->Run();
+	SubscriptionResponse subscription_response;
+	subscription_response.ParseFromString(message_or_status.value().payload());
+
+	if (subscription_response.topic().SerializeAsString() ==
+		subscription_topic_.SerializeAsString()) {
+		return ResponseOrStatus<SubscriptionResponse>(subscription_response);
+	}
+
+	return ResponseOrStatus<SubscriptionResponse>(
+		utils::Unexpected<v1::UStatus>(message_or_status.error()));
+		
 }
 
-UnsubscribeRequest RpcClientUSubscription::buildUnsubscriptionRequest() {
-	auto unsubscribe_request =
-	    utils::ProtoConverter::BuildUnSubscribeRequest(subscription_topic_);
-	return unsubscribe_request;
-}
 
-void RpcClientUSubscription::Unsubscribe(
-	google::protobuf::RpcController* controller,
-	const ::uprotocol::core::usubscription::v3::UnsubscribeRequest* request,
-	::uprotocol::core::usubscription::v3::UnsubscribeResponse* response,
-	::google::protobuf::Closure* done) {
+
+
+// UnsubscribeRequest RpcClientUSubscription::buildUnsubscriptionRequest() {
+// 	auto unsubscribe_request =
+// 	    utils::ProtoConverter::BuildUnSubscribeRequest(subscription_topic_);
+// 	return unsubscribe_request;
+// }
+
+// void RpcClientUSubscription::Unsubscribe(
+// 	google::protobuf::RpcController* controller,
+// 	const ::uprotocol::core::usubscription::v3::UnsubscribeRequest* request,
+// 	::uprotocol::core::usubscription::v3::UnsubscribeResponse* response,
+// 	::google::protobuf::Closure* done) {
 	
-	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
-	constexpr uint16_t RESOURCE_ID_UNSUBSCRIBE = 0x0002;
-	auto request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
-	auto priority = uprotocol::v1::UPriority::UPRIORITY_UNSPECIFIED;
+// 	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
+// 	constexpr uint16_t RESOURCE_ID_UNSUBSCRIBE = 0x0002;
+// 	auto request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
+// 	auto priority = uprotocol::v1::UPriority::UPRIORITY_UNSPECIFIED;
 	
-	rpc_client_ = std::make_unique<communication::RpcClient>(
-	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_UNSUBSCRIBE),
-	    priority, request_ttl);
+// 	rpc_client_ = std::make_unique<communication::RpcClient>(
+// 	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_UNSUBSCRIBE),
+// 	    priority, request_ttl);
 
-	auto on_response = [this, response](const auto& maybe_response) {
-		if (maybe_response.has_value() &&
-		    maybe_response.value().has_payload()) {
-			if (response->ParseFromString(maybe_response.value().payload())) {
-				if (response->SerializeAsString() == // TODO(lennart) topic specific? See subscribe
-				    subscription_topic_.SerializeAsString()) { 
-					unsubscribe_response_ = *response;
-				}
-			}
-		}
-	};
+// 	auto on_response = [this, response](const auto& maybe_response) {
+// 		if (maybe_response.has_value() &&
+// 		    maybe_response.value().has_payload()) {
+// 			if (response->ParseFromString(maybe_response.value().payload())) {
+// 				if (response->SerializeAsString() == // TODO(lennart) topic specific? See subscribe
+// 				    subscription_topic_.SerializeAsString()) { 
+// 					unsubscribe_response_ = *response;
+// 				}
+// 			}
+// 		}
+// 	};
 
-	// UnsubscribeRequest const unsubscribe_request = buildUnsubscriptionRequest();
-	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct
-	rpc_handle_ =
-	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
+// 	// UnsubscribeRequest const unsubscribe_request = buildUnsubscriptionRequest();
+// 	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct
+// 	rpc_handle_ =
+// 	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
 
-	// TODO(lennart) any handle for the response?
+// 	// TODO(lennart) any handle for the response?
+
+// 	subscriber_.reset();
+
+// 	done->Run();	
+// }
+
+// void RpcClientUSubscription::FetchSubscriptions(
+// 	google::protobuf::RpcController* controller,
+// 	const ::uprotocol::core::usubscription::v3::FetchSubscriptionsRequest* request,
+// 	::uprotocol::core::usubscription::v3::FetchSubscriptionsResponse* response,
+// 	::google::protobuf::Closure* done) {
 	
-	subscriber_.reset();
-
-	done->Run();	
-}
-
-void RpcClientUSubscription::FetchSubscriptions(
-	google::protobuf::RpcController* controller,
-	const ::uprotocol::core::usubscription::v3::FetchSubscriptionsRequest* request,
-	::uprotocol::core::usubscription::v3::FetchSubscriptionsResponse* response,
-	::google::protobuf::Closure* done) {
+// 	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
+// 	constexpr uint16_t RESOURCE_ID_FETCH_SUBSCRIPTIONS = 0x0003;
+// 	auto request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
+// 	auto priority = uprotocol::v1::UPriority::UPRIORITY_UNSPECIFIED;
 	
-	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
-	constexpr uint16_t RESOURCE_ID_FETCH_SUBSCRIPTIONS = 0x0003;
-	auto request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
-	auto priority = uprotocol::v1::UPriority::UPRIORITY_UNSPECIFIED;
+// 	rpc_client_ = std::make_unique<communication::RpcClient>(
+// 	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_FETCH_SUBSCRIPTIONS),
+// 	    priority, request_ttl);
+
+// 	auto on_response = [this, response](const auto& maybe_response) {
+// 		if (maybe_response.has_value() &&
+// 		    maybe_response.value().has_payload()) {
+// 			if (response->ParseFromString(maybe_response.value().payload())) {
+// 				if (response->SerializeAsString() == // TODO(lennart) topic specific? See subscribe
+// 				    subscription_topic_.SerializeAsString()) { 
+// 					fetch_subscription_response_ = *response;
+// 				}
+// 			}
+// 		}
+// 	};
+
+// 	// FetchSubscriptionsRequest const fetch_subscriptions_request = buildFetchSubscriptionsRequest();
+// 	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct
+
+// 	rpc_handle_ =
+// 	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
+
+// 	// TODO(lennart) any handle for the response?
+
+// 	done->Run();	
+// }
+
+// void RpcClientUSubscription::RegisterForNotifications(
+// 	google::protobuf::RpcController* controller,
+// 	const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
+// 	::uprotocol::core::usubscription::v3::NotificationsResponse* response,
+// 	::google::protobuf::Closure* done) {
 	
-	rpc_client_ = std::make_unique<communication::RpcClient>(
-	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_FETCH_SUBSCRIPTIONS),
-	    priority, request_ttl);
-
-	auto on_response = [this, response](const auto& maybe_response) {
-		if (maybe_response.has_value() &&
-		    maybe_response.value().has_payload()) {
-			if (response->ParseFromString(maybe_response.value().payload())) {
-				if (response->SerializeAsString() == // TODO(lennart) topic specific? See subscribe
-				    subscription_topic_.SerializeAsString()) { 
-					fetch_subscription_response_ = *response;
-				}
-			}
-		}
-	};
-
-	// FetchSubscriptionsRequest const fetch_subscriptions_request = buildFetchSubscriptionsRequest();
-	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct
-
-	rpc_handle_ =
-	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
-
-	// TODO(lennart) any handle for the response?
-
-	done->Run();	
-}
-
-void RpcClientUSubscription::RegisterForNotifications(
-	google::protobuf::RpcController* controller,
-	const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
-	::uprotocol::core::usubscription::v3::NotificationsResponse* response,
-	::google::protobuf::Closure* done) {
+// 	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
+// 	constexpr uint16_t RESOURCE_ID_REGISTER_FOR_NOTIFICATIONS = 0x0006;
+// 	auto request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
+// 	auto priority = uprotocol::v1::UPriority::UPRIORITY_UNSPECIFIED;
 	
-	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
-	constexpr uint16_t RESOURCE_ID_REGISTER_FOR_NOTIFICATIONS = 0x0006;
-	auto request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
-	auto priority = uprotocol::v1::UPriority::UPRIORITY_UNSPECIFIED;
+// 	rpc_client_ = std::make_unique<communication::RpcClient>(
+// 	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_REGISTER_FOR_NOTIFICATIONS),
+// 	    priority, request_ttl);
+
+// 	auto on_response = [this, response](const auto& maybe_response) {
+// 		if (maybe_response.has_value() &&
+// 		    maybe_response.value().has_payload()) {
+// 			if (response->ParseFromString(maybe_response.value().payload())) {
+// 				if (response->SerializeAsString() == // TODO(lennart) topic specific? See subscribe
+// 				    subscription_topic_.SerializeAsString()) { 
+// 						notification_response_ = *response;
+// 				}
+// 			}
+// 		}
+// 	};
+
+// 	// NotificationsRequest const register_notifications_request = buildRegisterNotificationsRequest();
+// 	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct
+
+// 	rpc_handle_ =
+// 	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
+
+// 	// TODO(lennart) any handle for the response?
+
+// 	done->Run();	
+// }
+
+// void RpcClientUSubscription::UnregisterForNotifications(
+// 	google::protobuf::RpcController* controller,
+// 	const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
+// 	::uprotocol::core::usubscription::v3::NotificationsResponse* response,
+// 	::google::protobuf::Closure* done) {
 	
-	rpc_client_ = std::make_unique<communication::RpcClient>(
-	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_REGISTER_FOR_NOTIFICATIONS),
-	    priority, request_ttl);
-
-	auto on_response = [this, response](const auto& maybe_response) {
-		if (maybe_response.has_value() &&
-		    maybe_response.value().has_payload()) {
-			if (response->ParseFromString(maybe_response.value().payload())) {
-				if (response->SerializeAsString() == // TODO(lennart) topic specific? See subscribe
-				    subscription_topic_.SerializeAsString()) { 
-						notification_response_ = *response;
-				}
-			}
-		}
-	};
-
-	// NotificationsRequest const register_notifications_request = buildRegisterNotificationsRequest();
-	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct
-
-	rpc_handle_ =
-	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
-
-	// TODO(lennart) any handle for the response?
-
-	done->Run();	
-}
-
-void RpcClientUSubscription::UnregisterForNotifications(
-	google::protobuf::RpcController* controller,
-	const ::uprotocol::core::usubscription::v3::NotificationsRequest* request,
-	::uprotocol::core::usubscription::v3::NotificationsResponse* response,
-	::google::protobuf::Closure* done) {
+// 	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
+// 	constexpr uint16_t RESOURCE_ID_UNREGISTER_FOR_NOTIFICATIONS = 0x0007;
+// 	auto request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
+// 	auto priority = uprotocol::v1::UPriority::UPRIORITY_UNSPECIFIED;
 	
-	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
-	constexpr uint16_t RESOURCE_ID_UNREGISTER_FOR_NOTIFICATIONS = 0x0007;
-	auto request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
-	auto priority = uprotocol::v1::UPriority::UPRIORITY_UNSPECIFIED;
+// 	rpc_client_ = std::make_unique<communication::RpcClient>(
+// 	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_UNREGISTER_FOR_NOTIFICATIONS),
+// 	    priority, request_ttl);
+
+// 	auto on_response = [this, response](const auto& maybe_response) {
+// 		if (maybe_response.has_value() &&
+// 		    maybe_response.value().has_payload()) {
+// 			if (response->ParseFromString(maybe_response.value().payload())) {
+// 				if (response->SerializeAsString() == // TODO(lennart) topic specific? See subscribe
+// 				    subscription_topic_.SerializeAsString()) { 
+// 						notification_response_ = *response;
+// 				}
+// 			}
+// 		}
+// 	};
+
+// 	// NotificationsRequest const unregister_notifications_request = buildUnregisterNotificationsRequest();
+// 	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct
+
+// 	rpc_handle_ =
+// 	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
+
+// 	// TODO(lennart) any handle for the response?
+
+// 	done->Run();	
+// }
+
+// void RpcClientUSubscription::FetchSubscribers(
+// 	google::protobuf::RpcController* controller,
+// 	const ::uprotocol::core::usubscription::v3::FetchSubscribersRequest* request,
+// 	::uprotocol::core::usubscription::v3::FetchSubscribersResponse* response,
+// 	::google::protobuf::Closure* done) {
 	
-	rpc_client_ = std::make_unique<communication::RpcClient>(
-	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_UNREGISTER_FOR_NOTIFICATIONS),
-	    priority, request_ttl);
-
-	auto on_response = [this, response](const auto& maybe_response) {
-		if (maybe_response.has_value() &&
-		    maybe_response.value().has_payload()) {
-			if (response->ParseFromString(maybe_response.value().payload())) {
-				if (response->SerializeAsString() == // TODO(lennart) topic specific? See subscribe
-				    subscription_topic_.SerializeAsString()) { 
-						notification_response_ = *response;
-				}
-			}
-		}
-	};
-
-	// NotificationsRequest const unregister_notifications_request = buildUnregisterNotificationsRequest();
-	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct
-
-	rpc_handle_ =
-	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
-
-	// TODO(lennart) any handle for the response?
-
-	done->Run();	
-}
-
-void RpcClientUSubscription::FetchSubscribers(
-	google::protobuf::RpcController* controller,
-	const ::uprotocol::core::usubscription::v3::FetchSubscribersRequest* request,
-	::uprotocol::core::usubscription::v3::FetchSubscribersResponse* response,
-	::google::protobuf::Closure* done) {
+// 	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
+// 	constexpr uint16_t RESOURCE_ID_FETCH_SUBSCRIBERS = 0x0008;
+// 	auto request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
+// 	auto priority = uprotocol::v1::UPriority::UPRIORITY_UNSPECIFIED;
 	
-	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
-	constexpr uint16_t RESOURCE_ID_FETCH_SUBSCRIBERS = 0x0008;
-	auto request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
-	auto priority = uprotocol::v1::UPriority::UPRIORITY_UNSPECIFIED;
-	
-	rpc_client_ = std::make_unique<communication::RpcClient>(
-	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_FETCH_SUBSCRIBERS),
-	    priority, request_ttl);
+// 	rpc_client_ = std::make_unique<communication::RpcClient>(
+// 	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_FETCH_SUBSCRIBERS),
+// 	    priority, request_ttl);
 
-	auto on_response = [this, response](const auto& maybe_response) {
-		if (maybe_response.has_value() &&
-		    maybe_response.value().has_payload()) {
-			if (response->ParseFromString(maybe_response.value().payload())) {
-				if (response->SerializeAsString() == // TODO(lennart) topic specific? See subscribe
-				    subscription_topic_.SerializeAsString()) { 
-						fetch_subscribers_response_ = *response;
-				}
-			}
-		}
-	};
+// 	auto on_response = [this, response](const auto& maybe_response) {
+// 		if (maybe_response.has_value() &&
+// 		    maybe_response.value().has_payload()) {
+// 			if (response->ParseFromString(maybe_response.value().payload())) {
+// 				if (response->SerializeAsString() == // TODO(lennart) topic specific? See subscribe
+// 				    subscription_topic_.SerializeAsString()) { 
+// 						fetch_subscribers_response_ = *response;
+// 				}
+// 			}
+// 		}
+// 	};
 
-	// FetchSubscribersRequest const fetch_subscribers_request = buildFetchSubscribersRequest();
-	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct
+// 	// FetchSubscribersRequest const fetch_subscribers_request = buildFetchSubscribersRequest();
+// 	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct
 
-	rpc_handle_ =
-	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
+// 	rpc_handle_ =
+// 	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
 
-	// TODO(lennart) any handle for the response?
+// 	// TODO(lennart) any handle for the response?
 
-	done->Run();	
-}
+// 	done->Run();	
+// }
 
 }  // namespace uprotocol::core::usubscription::v3

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -1,9 +1,97 @@
-#include "up-cpp/client/usubscription/v3/RpcClientUSubscription.h"
-#include <sys/types.h>
-#include <uprotocol/v1/uri.pb.h>
+// SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <up-cpp/client/usubscription/v3/RpcClientUSubscription.h>
+#include <uprotocol/core/usubscription/v3/usubscription.pb.h>
+
+#include <utility>
 
 namespace uprotocol::core::usubscription::v3 {
-	using Payload = datamodel::builder::Payload;
+
+void someCallBack(const uprotocol::v1::UMessage& message) {
+	// Print the message
+	std::cout << message.DebugString() << std::endl;
+}
+
+RpcClientUSubscription::RpcClientUSubscription(std::shared_ptr<uprotocol::transport::UTransport> transport,
+                   v1::UUri subscription_topic,
+                   RpcClientUSubscriptionOptions rpc_client_usubscription_options)
+    : transport_(std::move(transport)),
+      subscription_topic_(std::move(subscription_topic)),
+      rpc_client_usubscription_options_(std::move(rpc_client_usubscription_options)),
+      rpc_client_(nullptr) {
+	// Initialize uSubscriptionUUriBuilder_
+	uSubscriptionUUriBuilder_ = USubscriptionUUriBuilder();
+}
+
+// [[nodiscard]] RpcClientUSubscription::RpcClientUSubscriptionOrStatus RpcClientUSubscription::create(
+//     std::shared_ptr<transport::UTransport> transport,
+//     const v1::UUri& subscription_topic, ListenCallback&& callback,
+//     v1::UPriority priority, std::chrono::milliseconds subscription_request_ttl,
+//     RpcClientUSubscriptionOptions rpc_client_usubscription_options) {
+// 	auto rpc_client_usubscription = std::make_unique<RpcClientUSubscription>(
+// 	    std::forward<std::shared_ptr<transport::UTransport>>(transport),
+// 	    std::forward<const v1::UUri>(subscription_topic),
+// 	    std::forward<RpcClientUSubscriptionOptions>(rpc_client_usubscription_options));
+
+// 	// Attempt to connect create notification sink for updates.
+// 	auto status = rpc_client_usubscription->createNotificationSink();
+// 	if (status.code() == v1::UCode::OK) {
+// 		status = rpc_client_usubscription->subscribe(priority, subscription_request_ttl,
+// 		                             std::move(callback));
+// 		if (status.code() == v1::UCode::OK) {
+// 			return RpcClientUSubscriptionOrStatus(std::move(rpc_client_usubscription));
+// 		}
+// 		return RpcClientUSubscriptionOrStatus(utils::Unexpected<v1::UStatus>(status));
+// 	}
+// 	// If connection fails, return the error status.
+// 	return RpcClientUSubscriptionOrStatus(utils::Unexpected<v1::UStatus>(status));
+// }
+
+v1::UStatus RpcClientUSubscription::createNotificationSink() {
+	auto notification_sink_callback = [this](const v1::UMessage& update) {
+		if (update.has_payload()) {
+			Update data;
+			if (data.ParseFromString(update.payload())) {
+				if (data.topic().SerializeAsString() ==
+				    subscription_topic_.SerializeAsString()) {
+					subscription_update_ = std::move(data);
+				}
+			}
+		}
+	};
+
+	auto notification_topic = uSubscriptionUUriBuilder_.getNotificationUri();
+
+	auto result = communication::NotificationSink::create(
+	    transport_, std::move(notification_sink_callback), notification_topic);
+
+	if (result.has_value()) {
+		noficationSinkHandle_ = std::move(result).value();
+		v1::UStatus status;
+		status.set_code(v1::UCode::OK);
+		return status;
+	}
+	return result.error();
+}
+
+SubscriptionRequest RpcClientUSubscription::buildSubscriptionRequest() {
+	auto attributes = utils::ProtoConverter::BuildSubscribeAttributes(
+	    rpc_client_usubscription_options_.when_expire, rpc_client_usubscription_options_.subscription_details,
+	    rpc_client_usubscription_options_.sample_period_ms);
+
+	auto subscription_request = utils::ProtoConverter::BuildSubscriptionRequest(
+	    subscription_topic_, attributes);
+	return subscription_request;
+}
 
 void RpcClientUSubscription::Subscribe(
 	google::protobuf::RpcController* controller,
@@ -12,59 +100,95 @@ void RpcClientUSubscription::Subscribe(
 	::google::protobuf::Closure* done) {
 	
 	constexpr uint16_t RESOURCE_ID_SUBSCRIBE = 0x0001;
-	// TODO(lennart): needs to be set
-	v1::UPriority priority;
-	std::chrono::milliseconds subscription_request_ttl;
+	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
+	auto subscription_request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
+	auto priority = uprotocol::v1::UPriority::UPRIORITY_CS4; // TODO(lennart) priority
 
-	if ((request == nullptr) || (response == nullptr) || (done == nullptr)) {
-		controller->SetFailed("Invalid input parameters");
-		done->Run();
-		return;
-	}
+	auto options = uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions();
+
 
 	rpc_client_ = std::make_unique<communication::RpcClient>(
 	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_SUBSCRIBE),
 	    priority, subscription_request_ttl);
-	
+
 	auto on_response = [this, response](const auto& maybe_response) {
 		if (maybe_response.has_value() &&
-			maybe_response.value().has_payload()) {
+		    maybe_response.value().has_payload()) {
 			if (response->ParseFromString(maybe_response.value().payload())) {
 				if (response->topic().SerializeAsString() ==
-					subscription_topic_.SerializeAsString()) {
+				    subscription_topic_.SerializeAsString()) {
 					subscription_response_ = *response;
 				}
 			}
 		}
 	};
 
-	try {
-		auto payload = datamodel::builder::Payload(*request);
+	// SubscriptionRequest const subscription_request = buildSubscriptionRequest();
+	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct, has been subscription_request before
 
-		rpc_handle_ = rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
+	rpc_handle_ =
+	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
 
-		auto result = communication::Subscriber::subscribe(
-			transport_, subscription_topic_, std::move(callback)); // TODO(lennart) callback? 
+	// response->CopyFrom(rpc_handle_.value);	
 
-		if (static_cast<int>(rpc_handle_.isConnected()) == v1::OK) {		// TODO(lennart): check if this is correct
-			response->CopyFrom(rpc_handle_.value);  // Copy data to the response
-		} else {
-			controller->SetFailed("RPC call failed");
-		}
-		
-	} catch (const std::exception& e) {
-		controller->SetFailed(std::string("Exception during Subscribe: ") + e.what());
+	auto subscription_callback = someCallBack;
+	// Create a L2 subscription
+	auto result = communication::Subscriber::subscribe(
+	    transport_, subscription_topic_, std::move(subscription_callback));
+
+	if (result.has_value()) {
+		subscriber_ = std::move(result).value();
+		v1::UStatus status;
+		status.set_code(v1::UCode::OK);
+		// return status;
+		done->Run();
 	}
-
+	controller->SetFailed("result.error()");
 	done->Run();
 }
 
-// Backup
-	// SubscriptionResponse RpcClientUSubscription::subscribe(
-    // const SubscriptionRequest& subscription_request) {
-	// 	Payload test_test(subscription_request);
-	// 	auto invoke_handle = client_->invokeMethod(test_test, //TODO(max));
-	//     return SubscriptionResponse();
-    // }
+UnsubscribeRequest RpcClientUSubscription::buildUnsubscriptionRequest() {
+	auto unsubscribe_request =
+	    utils::ProtoConverter::BuildUnSubscribeRequest(subscription_topic_);
+	return unsubscribe_request;
+}
 
-} // namespace uprotocol::core::usubscription::v3
+void RpcClientUSubscription::Unsubscribe(
+	google::protobuf::RpcController* controller,
+	const ::uprotocol::core::usubscription::v3::UnsubscribeRequest* request,
+	::uprotocol::core::usubscription::v3::UnsubscribeResponse* response,
+	::google::protobuf::Closure* done) {
+	
+	constexpr int REQUEST_TTL_TIME = 0x8000; // TODO(lennart) time?
+	constexpr uint16_t RESOURCE_ID_UNSUBSCRIBE = 0x0002;
+	auto request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
+	auto priority = uprotocol::v1::UPriority::UPRIORITY_CS4; // TODO(lennart) priority
+	
+	rpc_client_ = std::make_unique<communication::RpcClient>(
+	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_UNSUBSCRIBE),
+	    priority, request_ttl);
+
+	auto on_response = [this, response](const auto& maybe_response) {
+		if (maybe_response.has_value() &&
+		    maybe_response.value().has_payload()) {
+			if (response->ParseFromString(maybe_response.value().payload())) {
+				// if (response->topic().SerializeAsString() == // TODO(lennart) see if this check is somehow possible
+				//     subscription_topic_.SerializeAsString()) { 
+					unsubscribe_response_ = *response;
+				// }
+			}
+		}
+	};
+
+	// UnsubscribeRequest const unsubscribe_request = buildUnsubscriptionRequest();
+	auto payload = datamodel::builder::Payload(*request); // TODO(lennart) check if request is correct, has been subscription_request before
+
+	rpc_handle_ =
+	    rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
+
+	subscriber_.reset();
+
+	done->Run();	
+}
+
+}  // namespace uprotocol::core::usubscription::v3

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -19,7 +19,6 @@
 #include <utility>
 
 #include "up-cpp/communication/RpcClient.h"
-#include "up-cpp/transport/UTransport.h"
 
 constexpr uint16_t RESOURCE_ID_SUBSCRIBE = 0x0001;
 // TODO(lennart) see default_call_options() for the request in Rust
@@ -47,7 +46,7 @@ RpcClientUSubscription::subscribe(
 
 	if (!message_or_status.has_value()) {
 		return ResponseOrStatus<SubscriptionResponse>(
-		    utils::Unexpected<v1::UStatus>(std::move(message_or_status.error())));
+		    utils::Unexpected<v1::UStatus>(message_or_status.error()));
 	}
 
 	SubscriptionResponse subscription_response;
@@ -56,7 +55,7 @@ RpcClientUSubscription::subscribe(
 	if (subscription_response.topic().SerializeAsString() !=
 	    subscription_request.topic().SerializeAsString()) {
 		return ResponseOrStatus<SubscriptionResponse>(
-			utils::Unexpected<v1::UStatus>(std::move(message_or_status.error())));
+			utils::Unexpected<v1::UStatus>(message_or_status.error()));
 	}
 
 	return ResponseOrStatus<SubscriptionResponse>(std::move(subscription_response));

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -24,7 +24,7 @@
 constexpr uint16_t RESOURCE_ID_SUBSCRIBE = 0x0001;
 // TODO(lennart) see default_call_options() for the request in Rust
 constexpr auto SUBSCRIPTION_REQUEST_TTL =
-    std::chrono::milliseconds(0x0800);  // TODO(lennart) change time
+    std::chrono::milliseconds(0x8000);  // TODO(lennart) change time
 auto priority = uprotocol::v1::UPriority::UPRIORITY_CS4;  // MUST be >= 4
 
 namespace uprotocol::core::usubscription::v3 {

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -40,9 +40,7 @@ RpcClientUSubscription::subscribe(
 
 	datamodel::builder::Payload payload(subscription_request);
 
-	auto invoke_future = rpc_client.invokeMethod(std::move(payload));
-
-	auto message_or_status = invoke_future.get();
+	auto message_or_status = rpc_client.invokeMethod(std::move(payload)).get();
 
 	if (!message_or_status.has_value()) {
 		return ResponseOrStatus<SubscriptionResponse>(

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -131,7 +131,7 @@ void RpcClientUSubscription::Subscribe(
 
 	// response->CopyFrom(rpc_handle_.value);	
 
-	auto subscription_callback = someCallBack;
+	auto subscription_callback = someCallBack; // TODO(lennart) update with correct callback
 	// Create a L2 subscription
 	auto result = communication::Subscriber::subscribe(
 	    transport_, subscription_topic_, std::move(subscription_callback));
@@ -143,7 +143,9 @@ void RpcClientUSubscription::Subscribe(
 		// return status;
 		done->Run();
 	}
+
 	controller->SetFailed("result.error()");
+	
 	done->Run();
 }
 

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -1,18 +1,67 @@
-//
-// Created by max on 28.04.25.
-//
-
 #include "up-cpp/client/usubscription/v3/RpcClientUSubscription.h"
+#include <sys/types.h>
+#include <uprotocol/v1/uri.pb.h>
 
 namespace uprotocol::core::usubscription::v3 {
 	using Payload = datamodel::builder::Payload;
 
-	SubscriptionResponse RpcClientUSubscription::subscribe(
-    const SubscriptionRequest& subscription_request) {
-		Payload test_test(subscription_request);
-		auto invoke_handle = client_->invokeMethod(test_test, //TODO(max));
-	    return SubscriptionResponse();
-    }
+void RpcClientUSubscription::Subscribe(
+	google::protobuf::RpcController* controller,
+	const ::uprotocol::core::usubscription::v3::SubscriptionRequest* request,
+	::uprotocol::core::usubscription::v3::SubscriptionResponse* response,
+	::google::protobuf::Closure* done) {
+	
+	constexpr uint16_t RESOURCE_ID_SUBSCRIBE = 0x0001;
+	// TODO(lennart): needs to be set
+	v1::UPriority priority;
+	std::chrono::milliseconds subscription_request_ttl;
 
-    } // namespace uprotocol::core::usubscription::v3
+	if ((request == nullptr) || (response == nullptr) || (done == nullptr)) {
+		controller->SetFailed("Invalid input parameters");
+		done->Run();
+		return;
+	}
 
+	rpc_client_ = std::make_unique<communication::RpcClient>(
+	    transport_, uSubscriptionUUriBuilder_.getServiceUriWithResourceId(RESOURCE_ID_SUBSCRIBE),
+	    priority, subscription_request_ttl);
+	
+	auto on_response = [this, response](const auto& maybe_response) {
+		if (maybe_response.has_value() &&
+			maybe_response.value().has_payload()) {
+			if (response->ParseFromString(maybe_response.value().payload())) {
+				if (response->topic().SerializeAsString() ==
+					subscription_topic_.SerializeAsString()) {
+					subscription_response_ = *response;
+				}
+			}
+		}
+	};
+
+	try {
+		auto payload = datamodel::builder::Payload(request);
+
+		rpc_handle_ = rpc_client_->invokeMethod(std::move(payload), std::move(on_response));
+
+		if (static_cast<int>(rpc_handle_.isConnected()) == v1::OK) {		// TODO(lennart): check if this is correct
+			response->CopyFrom(rpc_handle_.value);  // Copy data to the response
+		} else {
+			controller->SetFailed("RPC call failed");
+		}
+		
+	} catch (const std::exception& e) {
+		controller->SetFailed(std::string("Exception during Subscribe: ") + e.what());
+	}
+
+	done->Run();
+}
+
+// Backup
+	// SubscriptionResponse RpcClientUSubscription::subscribe(
+    // const SubscriptionRequest& subscription_request) {
+	// 	Payload test_test(subscription_request);
+	// 	auto invoke_handle = client_->invokeMethod(test_test, //TODO(max));
+	//     return SubscriptionResponse();
+    // }
+
+} // namespace uprotocol::core::usubscription::v3

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -43,13 +43,14 @@ RpcClientUSubscription::subscribe(
 	auto message_or_status = rpc_client.invokeMethod(std::move(payload)).get();
 
 	if (!message_or_status.has_value()) {
+		spdlog::error("Failed to subscribe");
 		return ResponseOrStatus<SubscriptionResponse>(
 		    utils::Unexpected<v1::UStatus>(message_or_status.error()));
 	}
-
+	spdlog::debug("Received subscription response");
 	SubscriptionResponse subscription_response;
 	subscription_response.ParseFromString(message_or_status.value().payload());
-
+	spdlog::debug("Parsed subscription response");
 	if (subscription_response.topic().SerializeAsString() !=
 	    subscription_request.topic().SerializeAsString()) {
 		return ResponseOrStatus<SubscriptionResponse>(

--- a/src/client/usubscription/v3/RpcClientUSubscription.cpp
+++ b/src/client/usubscription/v3/RpcClientUSubscription.cpp
@@ -23,7 +23,7 @@
 constexpr uint16_t RESOURCE_ID_SUBSCRIBE = 0x0001;
 // TODO(lennart) see default_call_options() for the request in Rust
 constexpr auto SUBSCRIPTION_REQUEST_TTL =
-    std::chrono::milliseconds(0x8000);  // TODO(lennart) change time
+    std::chrono::milliseconds(0x0800);  // TODO(lennart) change time
 auto priority = uprotocol::v1::UPriority::UPRIORITY_CS4;  // MUST be >= 4
 
 namespace uprotocol::core::usubscription::v3 {

--- a/src/client/usubscription/v3/USubscriptionUUriBuilder.cpp
+++ b/src/client/usubscription/v3/USubscriptionUUriBuilder.cpp
@@ -1,0 +1,34 @@
+#include "up-cpp/client/usubscription/v3/USubscriptionUUriBuilder.h"
+
+namespace uprotocol::core::usubscription::v3 {
+
+USubscriptionUUriBuilder::USubscriptionUUriBuilder() {
+	// Get the service descriptor
+	const google::protobuf::ServiceDescriptor* service =
+		uSubscription::descriptor();
+	const auto& service_options = service->options();
+
+	// Get the service options
+	const auto& service_name =
+		service_options.GetExtension(uprotocol::service_name);
+	const auto& service_version_major =
+		service_options.GetExtension(uprotocol::service_version_major);
+	const auto& service_id =
+		service_options.GetExtension(uprotocol::service_id);
+	const auto& notification_topic =
+		service_options.GetExtension(uprotocol::notification_topic, 0);
+
+	// Set the values in the URI
+	base_uri_.set_authority_name(service_name);
+	base_uri_.set_ue_id(service_id);
+	base_uri_.set_ue_version_major(service_version_major);
+	sink_resource_id_ = notification_topic.id();
+}
+
+v1::UUri USubscriptionUUriBuilder::getServiceUriWithResourceId(uint32_t resource_id) const {
+	v1::UUri uri = base_uri_;  // Copy the base URI
+	uri.set_resource_id(resource_id);
+	return uri;
+}
+
+} // namespace

--- a/src/client/usubscription/v3/USubscriptionUUriBuilder.cpp
+++ b/src/client/usubscription/v3/USubscriptionUUriBuilder.cpp
@@ -15,14 +15,11 @@ USubscriptionUUriBuilder::USubscriptionUUriBuilder() {
 		service_options.GetExtension(uprotocol::service_version_major);
 	const auto& service_id =
 		service_options.GetExtension(uprotocol::service_id);
-	const auto& notification_topic =
-		service_options.GetExtension(uprotocol::notification_topic, 0);
 
 	// Set the values in the URI
 	base_uri_.set_authority_name(service_name);
 	base_uri_.set_ue_id(service_id);
 	base_uri_.set_ue_version_major(service_version_major);
-	sink_resource_id_ = notification_topic.id();
 }
 
 v1::UUri USubscriptionUUriBuilder::getServiceUriWithResourceId(uint32_t resource_id) const {
@@ -31,4 +28,4 @@ v1::UUri USubscriptionUUriBuilder::getServiceUriWithResourceId(uint32_t resource
 	return uri;
 }
 
-} // namespace
+} // namespace uprotocol::core::usubscription::v3

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -86,6 +86,7 @@ add_coverage_test("ConsumerTest" coverage/client/usubscription/v3/ConsumerTest.c
 
 # core
 add_coverage_test("RpcClientUSubscriptionTest" coverage/client/usubscription/v3/RpcClientUSubscriptionTest.cpp)
+add_coverage_test("RequestBuilderTest" coverage/client/usubscription/v3/RequestBuilderTest.cpp)
 
 ########################## EXTRAS #############################################
 add_extra_test("PublisherSubscriberTest" extra/PublisherSubscriberTest.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,6 +84,9 @@ add_coverage_test("NotificationSourceTest" coverage/communication/NotificationSo
 # client
 add_coverage_test("ConsumerTest" coverage/client/usubscription/v3/ConsumerTest.cpp)
 
+# core
+add_coverage_test("RpcClientUSubscriptionTest" coverage/client/usubscription/v3/RpcClientUSubscriptionTest.cpp)
+
 ########################## EXTRAS #############################################
 add_extra_test("PublisherSubscriberTest" extra/PublisherSubscriberTest.cpp)
 add_extra_test("NotificationTest" extra/NotificationTest.cpp)

--- a/test/coverage/client/usubscription/v3/RequestBuilderTest.cpp
+++ b/test/coverage/client/usubscription/v3/RequestBuilderTest.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include "up-cpp/client/usubscription/v3/RequestBuilder.h"
+#include <uprotocol/core/usubscription/v3/usubscription.pb.h>
+#include <optional>
+#include <chrono>
+#include <google/protobuf/any.pb.h>
+
+namespace uprotocol::core::usubscription::v3 {
+
+class RequestBuilderTest : public ::testing::Test {
+protected:
+    RequestBuilder builder_;
+    USubscriptionOptions options_;
+
+    void SetUp() override {
+        options_.permission_level = 1;
+        options_.token = "sample_token";
+        options_.when_expire = std::chrono::system_clock::now() + std::chrono::hours(1);
+        options_.sample_period_ms = std::chrono::milliseconds(1000);
+        options_.subscriber_details = google::protobuf::Any(); 
+        options_.subscription_details = google::protobuf::Any();
+        
+        RequestBuilder builder(options_);
+    }
+    void TearDown() override {}
+
+    // Run once per execution of the test application.
+	// Used for setup of all tests. Has access to this instance.
+	RequestBuilderTest() = default;
+
+    // Run once per execution of the test application.
+	// Used only for global setup outside of tests.
+	static void SetUpTestSuite() {}
+	static void TearDownTestSuite() {}
+
+public:
+	~RequestBuilderTest() override = default;
+};
+
+TEST_F(RequestBuilderTest, BuildSubscriptionRequestWithOptions) {
+    v1::UUri topic;
+
+    SubscriptionRequest request = builder_.buildSubscriptionRequest(topic);
+
+    // Verify the attributes in the request
+    // TODO(lennart) did not find appropriate member to check the remaining attributes
+    EXPECT_EQ(request.topic().SerializeAsString(), topic.SerializeAsString());
+    EXPECT_EQ(request.attributes().has_expire(), options_.when_expire.has_value());
+    // EXPECT_EQ(request.attributes().subscription_details().SerializeAsString(), options_.subscription_details->SerializeAsString());
+    EXPECT_EQ(request.attributes().sample_period_ms(), options_.sample_period_ms.value().count());
+    // EXPECT_EQ(request.attributes().permission_level(), options_.permission_level.value());
+    // EXPECT_EQ(request.attributes().token(), options_.token.value());
+    // EXPECT_EQ(request.attributes().subscriber_details().SerializeAsString(), options_.subscriber_details->SerializeAsString());
+}
+
+} // namespace uprotocol::core::usubscription::v3

--- a/test/coverage/client/usubscription/v3/RpcClientUSubscriptionTest.cpp
+++ b/test/coverage/client/usubscription/v3/RpcClientUSubscriptionTest.cpp
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <google/protobuf/util/message_differencer.h>
+#include <gtest/gtest.h>
+#include <up-cpp/client/usubscription/v3/RpcClientUSubscription.h>
+#include <up-cpp/communication/NotificationSource.h>
+
+#include <string>
+
+#include "UTransportMock.h"
+
+namespace {
+using MsgDiff = google::protobuf::util::MessageDifferencer;
+
+void someCallBack(const uprotocol::v1::UMessage& message) {
+	// Print the message
+	std::cout << message.DebugString() << std::endl;
+}
+
+class RpcClientUSubscriptionTest : public testing::Test {
+private:
+	std::shared_ptr<uprotocol::test::UTransportMock> mockTransportClient_;
+	std::shared_ptr<uprotocol::test::UTransportMock> mockTransportServer_;
+	uprotocol::v1::UUri client_uuri;
+	uprotocol::v1::UUri server_uuri;
+	uprotocol::v1::UUri subscription_uuri;
+
+protected:
+	// Run once per TEST_F.
+	// Used to set up clean environments per test.
+
+	std::shared_ptr<uprotocol::test::UTransportMock> getMockTransportClient()
+	    const {
+		return mockTransportClient_;
+	}
+	std::shared_ptr<uprotocol::test::UTransportMock> getMockTransportServer()
+	    const {
+		return mockTransportServer_;
+	}
+	uprotocol::v1::UUri& getClientUUri() { return client_uuri; }
+	const uprotocol::v1::UUri& getServerUUri() const { return server_uuri; }
+	const uprotocol::v1::UUri& getSubscriptionUUri() const {
+		return subscription_uuri;
+	}
+
+	void SetUp() override {
+		constexpr uint32_t TEST_UE_ID = 0x18000;
+		constexpr uint32_t DEFAULT_RESOURCE_ID = 0x8000;
+		// Create a generic transport uri
+		client_uuri.set_authority_name("random_string");
+		client_uuri.set_ue_id(TEST_UE_ID);
+		client_uuri.set_ue_version_major(3);
+		client_uuri.set_resource_id(0);
+
+		// Set up a transport
+		mockTransportClient_ =
+		    std::make_shared<uprotocol::test::UTransportMock>(client_uuri);
+
+		// Craete server default uri and set up a transport
+		server_uuri.set_authority_name("core.usubscription");
+		server_uuri.set_ue_id(0);
+		server_uuri.set_ue_version_major(3);
+		server_uuri.set_resource_id(0);
+
+		mockTransportServer_ =
+		    std::make_shared<uprotocol::test::UTransportMock>(server_uuri);
+
+		// Create a generic subscription uri
+		subscription_uuri.set_authority_name("10.0.0.2");
+		subscription_uuri.set_ue_id(TEST_UE_ID);
+		subscription_uuri.set_ue_version_major(3);
+		subscription_uuri.set_resource_id(DEFAULT_RESOURCE_ID);
+	};
+	void TearDown() override {}
+
+	// Run once per execution of the test application.
+	// Used for setup of all tests. Has access to this instance.
+	RpcClientUSubscriptionTest() = default;
+
+	void buildDefaultSourceURI();
+	void buildValidNotificationURI();
+	void buildInValidNotificationURI();
+
+	// Run once per execution of the test application.
+	// Used only for global setup outside of tests.
+	static void SetUpTestSuite() {}
+	static void TearDownTestSuite() {}
+
+public:
+	~RpcClientUSubscriptionTest() override = default;
+};
+
+// Negative test case with no source filter
+TEST_F(RpcClientUSubscriptionTest, ConstructorTestSuccess) {  // NOLINT
+	// constexpr int REQUEST_TTL_TIME = 0x8000;
+	auto subscription_callback = someCallBack;
+	// auto subscribe_request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
+	// auto priority = uprotocol::v1::UPriority::UPRIORITY_CS4;
+
+	auto options = uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions();
+
+	auto rpc_client_usubscription_or_status =
+	    uprotocol::core::usubscription::v3::RpcClientUSubscription::create(
+	        getMockTransportClient(), getSubscriptionUUri(),
+	        subscription_callback, options);
+
+	// Ensure that the rpc_client_usubscription creation was successful
+	ASSERT_TRUE(rpc_client_usubscription_or_status.has_value());
+
+	// Obtain a pointer to the created rpc_client_usubscription instance
+	const auto& rpc_client_usubscription_ptr = rpc_client_usubscription_or_status.value();
+
+	// Verify that the rpc_client_usubscription pointer is not null, indicating successful
+	// creation
+	ASSERT_NE(rpc_client_usubscription_ptr, nullptr);
+}
+
+TEST_F(RpcClientUSubscriptionTest, SubscribeTestSuccess) {  // NOLINT
+	constexpr uint32_t DEFAULT_RESOURCE_ID = 0x8000;
+	// constexpr int REQUEST_TTL_TIME = 0x8000;
+	auto subscription_callback = someCallBack;
+	// auto subscribe_request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
+	// auto priority = uprotocol::v1::UPriority::UPRIORITY_CS4;
+
+	auto options = uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions();
+
+	auto rpc_client_usubscription_or_status =
+	    uprotocol::core::usubscription::v3::RpcClientUSubscription::create(
+	        getMockTransportClient(), getSubscriptionUUri(),
+	        subscription_callback, options);
+
+	// Ensure that the RpcClientUSubscription creation was successful
+	ASSERT_TRUE(rpc_client_usubscription_or_status.has_value());
+
+	// Obtain a pointer to the created rpc_client_usubscription instance
+	const auto& rpc_client_usubscription_ptr = rpc_client_usubscription_or_status.value();
+
+	// Verify that the rpc_client_usubscription pointer is not null, indicating successful
+	// creation
+	ASSERT_NE(rpc_client_usubscription_ptr, nullptr);
+
+	// Create notification source sink uri to match resource id of sink
+	auto notification_uuri = getServerUUri();
+	notification_uuri.set_resource_id(DEFAULT_RESOURCE_ID);
+
+	// set format UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY
+	auto format =
+	    uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY;
+
+	auto notification_source = uprotocol::communication::NotificationSource(
+	    getMockTransportServer(), std::move(notification_uuri),
+	    std::move(getClientUUri()), format);
+	// Build payload
+	const std::string data = "test";
+	auto payload = uprotocol::datamodel::builder::Payload(data, format);
+
+	notification_source.notify(std::move(payload));
+
+	// Check send count
+	EXPECT_TRUE(getMockTransportServer()->getSendCount() == 1);
+	EXPECT_TRUE(getMockTransportClient()->getSendCount() == 1);
+}
+
+TEST_F(RpcClientUSubscriptionTest, UnsubscribeTestSuccess) {  // NOLINT
+	constexpr uint32_t DEFAULT_RESOURCE_ID = 0x8000;
+	// constexpr int REQUEST_TTL_TIME = 0x8000;
+	auto subscription_callback = someCallBack;
+	// auto subscribe_request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
+	// auto priority = uprotocol::v1::UPriority::UPRIORITY_CS4;
+
+	auto options = uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions();
+
+	auto rpc_client_usubscription_or_status =
+	    uprotocol::core::usubscription::v3::RpcClientUSubscription::create(
+	        getMockTransportClient(), getSubscriptionUUri(),
+	        subscription_callback, options);
+
+	// Ensure that the rpc_client_usubscription creation was successful
+	ASSERT_TRUE(rpc_client_usubscription_or_status.has_value());
+
+	// Obtain a pointer to the created rpc_client_usubscription instance
+	const auto& rpc_client_usubscription_ptr = rpc_client_usubscription_or_status.value();
+
+	// Verify that the rpc_client_usubscription pointer is not null, indicating successful
+	// creation
+	ASSERT_NE(rpc_client_usubscription_ptr, nullptr);
+
+	// Create notification source sink uri to match resource id of sink
+	auto notification_uuri = getServerUUri();
+	notification_uuri.set_resource_id(DEFAULT_RESOURCE_ID);
+
+	// set format UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY
+	auto format =
+	    uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY;
+
+	auto notification_source = uprotocol::communication::NotificationSource(
+	    getMockTransportServer(), std::move(notification_uuri),
+	    std::move(getClientUUri()), format);
+	// Build payload
+	const std::string data = "test";
+	auto payload = uprotocol::datamodel::builder::Payload(data, format);
+
+	notification_source.notify(std::move(payload));
+
+	// Check send count
+	EXPECT_TRUE(getMockTransportServer()->getSendCount() == 1);
+	EXPECT_TRUE(getMockTransportClient()->getSendCount() == 1);
+
+	rpc_client_usubscription_ptr->Unsubscribe(nullptr, nullptr, nullptr, nullptr);
+
+	EXPECT_TRUE(getMockTransportClient()->getSendCount() == 2);
+}
+
+}  // namespace

--- a/test/coverage/client/usubscription/v3/RpcClientUSubscriptionTest.cpp
+++ b/test/coverage/client/usubscription/v3/RpcClientUSubscriptionTest.cpp
@@ -21,11 +21,6 @@
 namespace {
 using MsgDiff = google::protobuf::util::MessageDifferencer;
 
-void someCallBack(const uprotocol::v1::UMessage& message) {
-	// Print the message
-	std::cout << message.DebugString() << std::endl;
-}
-
 class RpcClientUSubscriptionTest : public testing::Test {
 private:
 	std::shared_ptr<uprotocol::test::UTransportMock> mockTransportClient_;
@@ -101,123 +96,36 @@ public:
 
 // Negative test case with no source filter
 TEST_F(RpcClientUSubscriptionTest, ConstructorTestSuccess) {  // NOLINT
-	// constexpr int REQUEST_TTL_TIME = 0x8000;
-	auto subscription_callback = someCallBack;
-	// auto subscribe_request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
-	// auto priority = uprotocol::v1::UPriority::UPRIORITY_CS4;
 
 	auto options = uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions();
-
-	auto rpc_client_usubscription_or_status =
-	    uprotocol::core::usubscription::v3::RpcClientUSubscription::create(
-	        getMockTransportClient(), getSubscriptionUUri(),
-	        subscription_callback, options);
-
-	// Ensure that the rpc_client_usubscription creation was successful
-	ASSERT_TRUE(rpc_client_usubscription_or_status.has_value());
-
-	// Obtain a pointer to the created rpc_client_usubscription instance
-	const auto& rpc_client_usubscription_ptr = rpc_client_usubscription_or_status.value();
-
-	// Verify that the rpc_client_usubscription pointer is not null, indicating successful
-	// creation
-	ASSERT_NE(rpc_client_usubscription_ptr, nullptr);
+	
+	auto rpc_client_usubscription =
+	    std::make_unique<uprotocol::core::usubscription::v3::
+	                     RpcClientUSubscription>(getMockTransportClient(),
+	                                              options);
+	
+	// Verify that the RpcClientUSubscription pointer is not null, indicating successful
+	ASSERT_NE(rpc_client_usubscription, nullptr);											  
 }
 
 TEST_F(RpcClientUSubscriptionTest, SubscribeTestSuccess) {  // NOLINT
-	constexpr uint32_t DEFAULT_RESOURCE_ID = 0x8000;
-	// constexpr int REQUEST_TTL_TIME = 0x8000;
-	auto subscription_callback = someCallBack;
-	// auto subscribe_request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
-	// auto priority = uprotocol::v1::UPriority::UPRIORITY_CS4;
-
+	
 	auto options = uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions();
+	
+	uprotocol::core::usubscription::v3::SubscriptionRequest subscription_request = uprotocol::utils::ProtoConverter::BuildSubscriptionRequest(
+	    getSubscriptionUUri(), uprotocol::core::usubscription::v3::SubscribeAttributes());
+	
+	auto rpc_client_usubscription =
+	    std::make_unique<uprotocol::core::usubscription::v3::
+	                     RpcClientUSubscription>(getMockTransportClient(),
+	                                              options);
+	
+	// Verify that the RpcClientUSubscription pointer is not null, indicating successful
+	ASSERT_NE(rpc_client_usubscription, nullptr);
 
-	auto rpc_client_usubscription_or_status =
-	    uprotocol::core::usubscription::v3::RpcClientUSubscription::create(
-	        getMockTransportClient(), getSubscriptionUUri(),
-	        subscription_callback, options);
+	auto result = rpc_client_usubscription->subscribe(subscription_request);
 
-	// Ensure that the RpcClientUSubscription creation was successful
-	ASSERT_TRUE(rpc_client_usubscription_or_status.has_value());
-
-	// Obtain a pointer to the created rpc_client_usubscription instance
-	const auto& rpc_client_usubscription_ptr = rpc_client_usubscription_or_status.value();
-
-	// Verify that the rpc_client_usubscription pointer is not null, indicating successful
-	// creation
-	ASSERT_NE(rpc_client_usubscription_ptr, nullptr);
-
-	// Create notification source sink uri to match resource id of sink
-	auto notification_uuri = getServerUUri();
-	notification_uuri.set_resource_id(DEFAULT_RESOURCE_ID);
-
-	// set format UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY
-	auto format =
-	    uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY;
-
-	auto notification_source = uprotocol::communication::NotificationSource(
-	    getMockTransportServer(), std::move(notification_uuri),
-	    std::move(getClientUUri()), format);
-	// Build payload
-	const std::string data = "test";
-	auto payload = uprotocol::datamodel::builder::Payload(data, format);
-
-	notification_source.notify(std::move(payload));
-
-	// Check send count
-	EXPECT_TRUE(getMockTransportServer()->getSendCount() == 1);
-	EXPECT_TRUE(getMockTransportClient()->getSendCount() == 1);
-}
-
-TEST_F(RpcClientUSubscriptionTest, UnsubscribeTestSuccess) {  // NOLINT
-	constexpr uint32_t DEFAULT_RESOURCE_ID = 0x8000;
-	// constexpr int REQUEST_TTL_TIME = 0x8000;
-	auto subscription_callback = someCallBack;
-	// auto subscribe_request_ttl = std::chrono::milliseconds(REQUEST_TTL_TIME);
-	// auto priority = uprotocol::v1::UPriority::UPRIORITY_CS4;
-
-	auto options = uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions();
-
-	auto rpc_client_usubscription_or_status =
-	    uprotocol::core::usubscription::v3::RpcClientUSubscription::create(
-	        getMockTransportClient(), getSubscriptionUUri(),
-	        subscription_callback, options);
-
-	// Ensure that the rpc_client_usubscription creation was successful
-	ASSERT_TRUE(rpc_client_usubscription_or_status.has_value());
-
-	// Obtain a pointer to the created rpc_client_usubscription instance
-	const auto& rpc_client_usubscription_ptr = rpc_client_usubscription_or_status.value();
-
-	// Verify that the rpc_client_usubscription pointer is not null, indicating successful
-	// creation
-	ASSERT_NE(rpc_client_usubscription_ptr, nullptr);
-
-	// Create notification source sink uri to match resource id of sink
-	auto notification_uuri = getServerUUri();
-	notification_uuri.set_resource_id(DEFAULT_RESOURCE_ID);
-
-	// set format UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY
-	auto format =
-	    uprotocol::v1::UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY;
-
-	auto notification_source = uprotocol::communication::NotificationSource(
-	    getMockTransportServer(), std::move(notification_uuri),
-	    std::move(getClientUUri()), format);
-	// Build payload
-	const std::string data = "test";
-	auto payload = uprotocol::datamodel::builder::Payload(data, format);
-
-	notification_source.notify(std::move(payload));
-
-	// Check send count
-	EXPECT_TRUE(getMockTransportServer()->getSendCount() == 1);
-	EXPECT_TRUE(getMockTransportClient()->getSendCount() == 1);
-
-	rpc_client_usubscription_ptr->Unsubscribe(nullptr, nullptr, nullptr, nullptr);
-
-	EXPECT_TRUE(getMockTransportClient()->getSendCount() == 2);
+	ASSERT_NE(&result, nullptr);
 }
 
 }  // namespace

--- a/test/coverage/client/usubscription/v3/RpcClientUSubscriptionTest.cpp
+++ b/test/coverage/client/usubscription/v3/RpcClientUSubscriptionTest.cpp
@@ -97,30 +97,35 @@ public:
 // Negative test case with no source filter
 TEST_F(RpcClientUSubscriptionTest, ConstructorTestSuccess) {  // NOLINT
 
-	auto options = uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions();
-	
-	auto rpc_client_usubscription =
-	    std::make_unique<uprotocol::core::usubscription::v3::
-	                     RpcClientUSubscription>(getMockTransportClient(),
-	                                              options);
-	
-	// Verify that the RpcClientUSubscription pointer is not null, indicating successful
-	ASSERT_NE(rpc_client_usubscription, nullptr);											  
+	auto options =
+	    uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions();
+
+	auto rpc_client_usubscription = std::make_unique<
+	    uprotocol::core::usubscription::v3::RpcClientUSubscription>(
+	    getMockTransportClient(), options);
+
+	// Verify that the RpcClientUSubscription pointer is not null, indicating
+	// successful
+	ASSERT_NE(rpc_client_usubscription, nullptr);
 }
 
 TEST_F(RpcClientUSubscriptionTest, SubscribeTestSuccess) {  // NOLINT
-	
-	auto options = uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions();
-	
-	uprotocol::core::usubscription::v3::SubscriptionRequest subscription_request = uprotocol::utils::ProtoConverter::BuildSubscriptionRequest(
-	    getSubscriptionUUri(), uprotocol::core::usubscription::v3::SubscribeAttributes());
-	
-	auto rpc_client_usubscription =
-	    std::make_unique<uprotocol::core::usubscription::v3::
-	                     RpcClientUSubscription>(getMockTransportClient(),
-	                                              options);
-	
-	// Verify that the RpcClientUSubscription pointer is not null, indicating successful
+
+	auto options =
+	    uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions();
+
+	uprotocol::core::usubscription::v3::SubscriptionRequest
+	    subscription_request =
+	        uprotocol::utils::ProtoConverter::BuildSubscriptionRequest(
+	            getSubscriptionUUri(),
+	            uprotocol::core::usubscription::v3::SubscribeAttributes());
+
+	auto rpc_client_usubscription = std::make_unique<
+	    uprotocol::core::usubscription::v3::RpcClientUSubscription>(
+	    getMockTransportClient(), options);
+
+	// Verify that the RpcClientUSubscription pointer is not null, indicating
+	// successful
 	ASSERT_NE(rpc_client_usubscription, nullptr);
 
 	auto result = rpc_client_usubscription->subscribe(subscription_request);

--- a/test/coverage/client/usubscription/v3/RpcClientUSubscriptionTest.cpp
+++ b/test/coverage/client/usubscription/v3/RpcClientUSubscriptionTest.cpp
@@ -97,12 +97,10 @@ public:
 // Negative test case with no source filter
 TEST_F(RpcClientUSubscriptionTest, ConstructorTestSuccess) {  // NOLINT
 
-	auto options =
-	    uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions();
 
 	auto rpc_client_usubscription = std::make_unique<
 	    uprotocol::core::usubscription::v3::RpcClientUSubscription>(
-	    getMockTransportClient(), options);
+	    getMockTransportClient());
 
 	// Verify that the RpcClientUSubscription pointer is not null, indicating
 	// successful
@@ -110,9 +108,6 @@ TEST_F(RpcClientUSubscriptionTest, ConstructorTestSuccess) {  // NOLINT
 }
 
 TEST_F(RpcClientUSubscriptionTest, SubscribeTestSuccess) {  // NOLINT
-
-	auto options =
-	    uprotocol::core::usubscription::v3::RpcClientUSubscriptionOptions();
 
 	uprotocol::core::usubscription::v3::SubscriptionRequest
 	    subscription_request =
@@ -122,7 +117,7 @@ TEST_F(RpcClientUSubscriptionTest, SubscribeTestSuccess) {  // NOLINT
 
 	auto rpc_client_usubscription = std::make_unique<
 	    uprotocol::core::usubscription::v3::RpcClientUSubscription>(
-	    getMockTransportClient(), options);
+	    getMockTransportClient());
 
 	// Verify that the RpcClientUSubscription pointer is not null, indicating
 	// successful

--- a/test/coverage/client/usubscription/v3/RpcClientUSubscriptionTest.cpp
+++ b/test/coverage/client/usubscription/v3/RpcClientUSubscriptionTest.cpp
@@ -14,8 +14,6 @@
 #include <up-cpp/client/usubscription/v3/RpcClientUSubscription.h>
 #include <up-cpp/communication/NotificationSource.h>
 
-#include <string>
-
 #include "UTransportMock.h"
 
 namespace {

--- a/test/coverage/client/usubscription/v3/RpcClientUSubscriptionTest.cpp
+++ b/test/coverage/client/usubscription/v3/RpcClientUSubscriptionTest.cpp
@@ -13,8 +13,12 @@
 #include <gtest/gtest.h>
 #include <up-cpp/client/usubscription/v3/RpcClientUSubscription.h>
 #include <up-cpp/communication/NotificationSource.h>
+#include <up-cpp/client/usubscription/v3/RequestBuilder.h>
 
 #include "UTransportMock.h"
+
+constexpr uint32_t TEST_UE_ID = 0x18000;
+constexpr uint32_t DEFAULT_RESOURCE_ID = 0x8000;
 
 namespace {
 using MsgDiff = google::protobuf::util::MessageDifferencer;
@@ -28,26 +32,21 @@ private:
 	uprotocol::v1::UUri subscription_uuri;
 
 protected:
-	// Run once per TEST_F.
-	// Used to set up clean environments per test.
 
 	std::shared_ptr<uprotocol::test::UTransportMock> getMockTransportClient()
 	    const {
 		return mockTransportClient_;
 	}
-	std::shared_ptr<uprotocol::test::UTransportMock> getMockTransportServer()
-	    const {
-		return mockTransportServer_;
-	}
-	uprotocol::v1::UUri& getClientUUri() { return client_uuri; }
-	const uprotocol::v1::UUri& getServerUUri() const { return server_uuri; }
 	const uprotocol::v1::UUri& getSubscriptionUUri() const {
 		return subscription_uuri;
 	}
 
+	const uprotocol::v1::UUri& getSubscriptionUuri() const { return subscription_uuri; }
+
+	// Run once per TEST_F.
+	// Used to set up clean environments per test.
+
 	void SetUp() override {
-		constexpr uint32_t TEST_UE_ID = 0x18000;
-		constexpr uint32_t DEFAULT_RESOURCE_ID = 0x8000;
 		// Create a generic transport uri
 		client_uuri.set_authority_name("random_string");
 		client_uuri.set_ue_id(TEST_UE_ID);
@@ -95,7 +94,6 @@ public:
 // Negative test case with no source filter
 TEST_F(RpcClientUSubscriptionTest, ConstructorTestSuccess) {  // NOLINT
 
-
 	auto rpc_client_usubscription = std::make_unique<
 	    uprotocol::core::usubscription::v3::RpcClientUSubscription>(
 	    getMockTransportClient());
@@ -107,11 +105,10 @@ TEST_F(RpcClientUSubscriptionTest, ConstructorTestSuccess) {  // NOLINT
 
 TEST_F(RpcClientUSubscriptionTest, SubscribeTestSuccess) {  // NOLINT
 
-	uprotocol::core::usubscription::v3::SubscriptionRequest
-	    subscription_request =
-	        uprotocol::utils::ProtoConverter::BuildSubscriptionRequest(
-	            getSubscriptionUUri(),
-	            uprotocol::core::usubscription::v3::SubscribeAttributes());
+	uprotocol::v1::UUri topic = getSubscriptionUUri();
+    uprotocol::core::usubscription::v3::RequestBuilder builder;  
+
+    uprotocol::utils::SubscriptionRequest subscription_request = builder.buildSubscriptionRequest(topic);
 
 	auto rpc_client_usubscription = std::make_unique<
 	    uprotocol::core::usubscription::v3::RpcClientUSubscription>(


### PR DESCRIPTION
Parsing the subscription request and its attributes seems to be complicated. 
Also see Consumer.h -> Components like USubscriptionUuriBuilder (currently implemented in Consumer and in own document) do not have any unit tests yet. Mocking the transport and the client might work well with consumer example.